### PR TITLE
fix: update manifest generation to include separators between files

### DIFF
--- a/.github/workflows/bazel-build.yml
+++ b/.github/workflows/bazel-build.yml
@@ -81,7 +81,7 @@ jobs:
           first=1
           for f in k8s/*.yaml; do
             if [ $first -eq 0 ]; then
-              echo -e "\n---" >> combined.yaml
+              printf "\n---\n" >> combined.yaml
             fi
             cat "$f" >> combined.yaml
             first=0

--- a/.github/workflows/bazel-build.yml
+++ b/.github/workflows/bazel-build.yml
@@ -76,8 +76,16 @@ jobs:
           git clone https://github.com/Anthony-Bible/password-exchange-deploy.git ./build
           echo "rendering k8s manifests"
 
-          # Create combined manifest file
-          cat k8s/*.yaml > combined.yaml
+          # Create combined manifest file with dashes between each file
+          rm -f combined.yaml
+          first=1
+          for f in k8s/*.yaml; do
+            if [ $first -eq 0 ]; then
+              echo -e "\n---" >> combined.yaml
+            fi
+            cat "$f" >> combined.yaml
+            first=0
+          done
 
           # Replace variables in the manifest
           sed -i "s/%{VERSION}/${VERSION}/g" combined.yaml

--- a/test-build.sh
+++ b/test-build.sh
@@ -58,7 +58,7 @@ rm -f combined.yaml
 first=1
 for f in k8s/*.yaml; do
   if [ $first -eq 0 ]; then
-    echo -e "\n---" >> combined.yaml
+    printf "\n---\n" >> combined.yaml
   fi
   cat "$f" >> combined.yaml
   first=0

--- a/test-build.sh
+++ b/test-build.sh
@@ -46,8 +46,24 @@ fi
 
 echo "Testing Kubernetes manifest generation..."
 cd ..
+
+# Set VERSION and PHASE
+VERSION="dev"
+PHASE=$(git rev-parse --short HEAD)
+
 source ./tools/bazel_stamp_vars.sh
-cat k8s/*.yaml > combined.yaml
+
+# Combine manifests with dashes between each file
+rm -f combined.yaml
+first=1
+for f in k8s/*.yaml; do
+  if [ $first -eq 0 ]; then
+    echo -e "\n---" >> combined.yaml
+  fi
+  cat "$f" >> combined.yaml
+  first=0
+done
+
 sed -i "s/%{VERSION}/${VERSION}/g" combined.yaml
 sed -i "s/%{PHASE}/${PHASE}/g" combined.yaml
 if [ -f combined.yaml ]; then
@@ -58,4 +74,3 @@ else
 fi
 
 echo "All tests passed!"
-

--- a/test-build.sh
+++ b/test-build.sh
@@ -57,7 +57,7 @@ source ./tools/bazel_stamp_vars.sh
 rm -f combined.yaml
 first=1
 for f in k8s/*.yaml; do
-  if [ $first -eq 0 ]; then
+  if [ "$first" -eq 0 ]; then
     printf "\n---\n" >> combined.yaml
   fi
   cat "$f" >> combined.yaml


### PR DESCRIPTION
This commit modifies the generation of Kubernetes manifests by adding dashes between concatenated YAML files. Changes were made in both the bazel-build.yml and test-build.sh scripts to ensure consistent output.