### PR TITLE
fix(db): prevent database connection leaks in error scenarios

### DIFF
--- a/app/cmd/reminder/reminder.go
+++ b/app/cmd/reminder/reminder.go
@@ -143,6 +143,9 @@ PASSWORDEXCHANGE_REMINDER_INTERVAL: Hours between reminders (1-720, default: 24)
 		}
 		storageAdapter := mysql.NewMySQLAdapter(dbConfig)
 		if mysqlAdapter, ok := storageAdapter.(*mysql.MySQLAdapter); ok {
+			// Set up defer before attempting connection
+			defer mysqlAdapter.Close()
+			
 			if err := mysqlAdapter.Connect(); err != nil {
 				log.Error().
 					Err(err).
@@ -152,7 +155,6 @@ PASSWORDEXCHANGE_REMINDER_INTERVAL: Hours between reminders (1-720, default: 24)
 					Msg("Failed to connect to database")
 				return
 			}
-			defer mysqlAdapter.Close()
 		}
 
 		// Initialize storage service

--- a/app/internal/domains/storage/adapters/secondary/mysql/adapter.go
+++ b/app/internal/domains/storage/adapters/secondary/mysql/adapter.go
@@ -35,6 +35,13 @@ func (m *MySQLAdapter) Connect() error {
 		return fmt.Errorf("%w: %v", domain.ErrDatabaseConnection, err)
 	}
 
+	// Use defer to ensure connection is closed if we don't successfully assign it
+	defer func() {
+		if m.db == nil {
+			db.Close()
+		}
+	}()
+
 	// Test the connection
 	if err := db.Ping(); err != nil {
 		log.Error().Err(err).Msg("Failed to ping MySQL database")

--- a/app/internal/domains/storage/adapters/secondary/mysql/adapter.go
+++ b/app/internal/domains/storage/adapters/secondary/mysql/adapter.go
@@ -35,15 +35,9 @@ func (m *MySQLAdapter) Connect() error {
 		return fmt.Errorf("%w: %v", domain.ErrDatabaseConnection, err)
 	}
 
-	// Use defer to ensure connection is closed if we don't successfully assign it
-	defer func() {
-		if m.db == nil {
-			db.Close()
-		}
-	}()
-
 	// Test the connection
 	if err := db.Ping(); err != nil {
+		db.Close() // Close connection if ping fails to prevent leak
 		log.Error().Err(err).Msg("Failed to ping MySQL database")
 		return fmt.Errorf("%w: %v", domain.ErrDatabaseConnection, err)
 	}


### PR DESCRIPTION
## Summary
• Fix critical database connection leaks that could lead to resource exhaustion
• Ensure proper cleanup using Go's idiomatic defer patterns for resource management

## Test plan
- [x] All existing tests pass
- [x] Build verification script completes successfully
- [x] Docker builds succeed for both main app and slackbot
- [x] Connection cleanup verified in both MySQL adapter and reminder command

🤖 Generated with [Claude Code](https://claude.ai/code)