### PR TITLE
fix(slackbot): correct gRPC stub casing and logger error formatting

### DIFF
--- a/slackbot/encryptionClient.py
+++ b/slackbot/encryptionClient.py
@@ -27,7 +27,7 @@ class EncryptionServiceClient(object):
             None.
         """
         self.channel = grpc.insecure_channel(f'{SERVER_ADDRESS}:{PORT}')
-        self.stub = encryption_pb2_grpc.messageServiceStub(self.channel)
+        self.stub = encryption_pb2_grpc.MessageServiceStub(self.channel)
     def generate_random_strng(self, length):
         """Generates a cryptographically random string from the given length
 

--- a/slackbot/program.py
+++ b/slackbot/program.py
@@ -53,7 +53,7 @@ try:
     installation_store.metadata.create_all(engine)
     oauth_state_store.metadata.create_all(engine)
 except Exception as e:
-    logger.error("Something went wrong creating intial dbs" + e)
+    logger.error("Something went wrong creating intial dbs: %s", e)
 
 bolt_app = App(
     logger=logger,


### PR DESCRIPTION
## Summary
- Fix `messageServiceStub` → `MessageServiceStub` casing in `encryptionClient.py` (caused `AttributeError` on startup)
- Fix `TypeError` in `program.py` error handler by using `%s` formatting instead of string concatenation with exception object

## Root Cause
Slackbot pods were in `CrashLoopBackOff` due to two bugs:
1. Missing `oauthUser` in Cloud SQL (fixed directly in GCP — user created with correct grants)
2. After DB fix, crash moved to `encryptionClient.py` — wrong casing on the gRPC stub class name
3. The `except` block in `program.py` would also crash with `TypeError` if DB setup failed

## Test plan
- [ ] CI builds and pushes new slackbot image
- [ ] Slackbot pods come up healthy after image rollout
- [ ] `/password` and `/encrypt` Slack commands work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)