### PR TITLE
refactor(encryption): align encryption domain with strict hexagonal architecture

### DIFF
--- a/app/cmd/encryption/encryption2.go
+++ b/app/cmd/encryption/encryption2.go
@@ -2,10 +2,11 @@ package encryption
 
 import (
 	encryptionGRPC "github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/adapters/primary/grpc"
+	loggerAdapter "github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/adapters/secondary/logger"
 	memoryKeygen "github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/adapters/secondary/memory"
+	viperConfig "github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/adapters/secondary/viper"
 	encryptionDomain "github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/domain"
 	"github.com/Anthony-Bible/password-exchange/app/internal/shared/config"
-	"github.com/Anthony-Bible/password-exchange/app/internal/shared/logging"
 	"github.com/go-kit/kit/transport/amqp"
 )
 
@@ -20,20 +21,27 @@ func (conf Config) startServer() {
 }
 
 func (conf Config) startHexagonalServer() {
-	address := "0.0.0.0:50051"
+	// Wire secondary adapters
+	logger := loggerAdapter.NewAdapter()
+	cfg := viperConfig.NewViperConfigAdapter()
+
+	if err := cfg.ValidateListenAddress(); err != nil {
+		logger.Fatal().Err(err).Msg("Invalid encryption listen address")
+	}
+	address := cfg.GetListenAddress()
 
 	// Create key generator (secondary adapter)
-	keyGenerator := memoryKeygen.NewKeyGenerator()
+	keyGenerator := memoryKeygen.NewKeyGenerator(logger)
 
 	// Create encryption service (domain)
-	encryptionService := encryptionDomain.NewEncryptionService(keyGenerator)
+	encryptionService := encryptionDomain.NewEncryptionService(keyGenerator, logger)
 
 	// Create gRPC server (primary adapter)
-	grpcServer := encryptionGRPC.NewGRPCServer(encryptionService, address)
+	grpcServer := encryptionGRPC.NewGRPCServer(encryptionService, address, logger)
 
 	// Start the server
-	logging.Info().Str("address", address).Msg("Starting encryption service with hexagonal architecture")
+	logger.Info().Str("address", address).Msg("Starting encryption service with hexagonal architecture")
 	if err := grpcServer.Start(); err != nil {
-		logging.Fatal().Err(err).Msg("Failed to start hexagonal encryption server")
+		logger.Fatal().Err(err).Msg("Failed to start hexagonal encryption server")
 	}
 }

--- a/app/cmd/root.go
+++ b/app/cmd/root.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"errors"
 	"os"
+	"strings"
 
 	"github.com/Anthony-Bible/password-exchange/app/internal/shared/logging"
 
@@ -73,6 +74,7 @@ func initConfig() {
 		logging.Info().Msgf("Using config file: %s", cfgFile)
 	}
 	viper.SetEnvPrefix("passwordexchange")
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.AutomaticEnv()
 	logging.SetLevel(viper.GetString("loglevel"))
 }

--- a/app/internal/domains/encryption/adapters/primary/grpc/server.go
+++ b/app/internal/domains/encryption/adapters/primary/grpc/server.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"net"
 
-	"github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/domain"
+	"github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/ports/contracts"
 	"github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/ports/primary"
-	"github.com/Anthony-Bible/password-exchange/app/internal/shared/logging"
+	"github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/ports/secondary"
 	pb "github.com/Anthony-Bible/password-exchange/app/pkg/pb/encryption"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
@@ -17,13 +17,15 @@ type GRPCServer struct {
 	pb.UnimplementedMessageServiceServer
 	encryptionService primary.EncryptionServicePort
 	address           string
+	logger            secondary.LoggerPort
 }
 
 // NewGRPCServer creates a new gRPC server for the encryption service
-func NewGRPCServer(encryptionService primary.EncryptionServicePort, address string) *GRPCServer {
+func NewGRPCServer(encryptionService primary.EncryptionServicePort, address string, logger secondary.LoggerPort) *GRPCServer {
 	return &GRPCServer{
 		encryptionService: encryptionService,
 		address:           address,
+		logger:            logger,
 	}
 }
 
@@ -31,7 +33,7 @@ func NewGRPCServer(encryptionService primary.EncryptionServicePort, address stri
 func (s *GRPCServer) Start() error {
 	lis, err := net.Listen("tcp", s.address)
 	if err != nil {
-		logging.Error().Err(err).Str("address", s.address).Msg("Failed to listen on address")
+		s.logger.Error().Err(err).Str("address", s.address).Msg("Failed to listen on address")
 		return err
 	}
 
@@ -39,9 +41,9 @@ func (s *GRPCServer) Start() error {
 	pb.RegisterMessageServiceServer(grpcServer, s)
 	reflection.Register(grpcServer)
 
-	logging.Info().Str("address", s.address).Msg("Starting encryption gRPC server")
+	s.logger.Info().Str("address", s.address).Msg("Starting encryption gRPC server")
 	if err := grpcServer.Serve(lis); err != nil {
-		logging.Error().Err(err).Msg("Failed to serve gRPC")
+		s.logger.Error().Err(err).Msg("Failed to serve gRPC")
 		return err
 	}
 
@@ -50,16 +52,16 @@ func (s *GRPCServer) Start() error {
 
 // EncryptMessage handles encryption requests
 func (s *GRPCServer) EncryptMessage(ctx context.Context, request *pb.EncryptedMessageRequest) (*pb.EncryptedMessageResponse, error) {
-	logging.Debug().Int("plaintextCount", len(request.GetPlainText())).Msg("Received encryption request")
+	s.logger.Debug().Int("plaintextCount", len(request.GetPlainText())).Msg("Received encryption request")
 
-	domainRequest := domain.EncryptionRequest{
+	domainRequest := contracts.EncryptionRequest{
 		Plaintext: request.GetPlainText(),
 		Key:       request.GetKey(),
 	}
 
 	response, err := s.encryptionService.Encrypt(ctx, domainRequest)
 	if err != nil {
-		logging.Error().Err(err).Msg("Encryption failed")
+		s.logger.Error().Err(err).Msg("Encryption failed")
 		return nil, err
 	}
 
@@ -67,22 +69,22 @@ func (s *GRPCServer) EncryptMessage(ctx context.Context, request *pb.EncryptedMe
 		Ciphertext: response.Ciphertext,
 	}
 
-	logging.Debug().Int("ciphertextCount", len(response.Ciphertext)).Msg("Successfully encrypted messages")
+	s.logger.Debug().Int("ciphertextCount", len(response.Ciphertext)).Msg("Successfully encrypted messages")
 	return pbResponse, nil
 }
 
 // DecryptMessage handles decryption requests
 func (s *GRPCServer) DecryptMessage(ctx context.Context, request *pb.DecryptedMessageRequest) (*pb.DecryptedMessageResponse, error) {
-	logging.Debug().Int("ciphertextCount", len(request.GetCiphertext())).Msg("Received decryption request")
+	s.logger.Debug().Int("ciphertextCount", len(request.GetCiphertext())).Msg("Received decryption request")
 
-	domainRequest := domain.DecryptionRequest{
+	domainRequest := contracts.DecryptionRequest{
 		Ciphertext: request.GetCiphertext(),
 		Key:        request.GetKey(),
 	}
 
 	response, err := s.encryptionService.Decrypt(ctx, domainRequest)
 	if err != nil {
-		logging.Error().Err(err).Msg("Decryption failed")
+		s.logger.Error().Err(err).Msg("Decryption failed")
 		return nil, err
 	}
 
@@ -90,21 +92,21 @@ func (s *GRPCServer) DecryptMessage(ctx context.Context, request *pb.DecryptedMe
 		Plaintext: response.Plaintext,
 	}
 
-	logging.Debug().Int("plaintextCount", len(response.Plaintext)).Msg("Successfully decrypted messages")
+	s.logger.Debug().Int("plaintextCount", len(response.Plaintext)).Msg("Successfully decrypted messages")
 	return pbResponse, nil
 }
 
 // GenerateRandomString handles random key generation requests
 func (s *GRPCServer) GenerateRandomString(ctx context.Context, request *pb.Randomrequest) (*pb.Randomresponse, error) {
-	logging.Debug().Int32("length", request.GetRandomLength()).Msg("Received random key generation request")
+	s.logger.Debug().Int32("length", request.GetRandomLength()).Msg("Received random key generation request")
 
-	domainRequest := domain.RandomRequest{
+	domainRequest := contracts.RandomRequest{
 		Length: request.GetRandomLength(),
 	}
 
 	response, err := s.encryptionService.GenerateRandomKey(ctx, domainRequest)
 	if err != nil {
-		logging.Error().Err(err).Msg("Random key generation failed")
+		s.logger.Error().Err(err).Msg("Random key generation failed")
 		return nil, err
 	}
 
@@ -113,6 +115,6 @@ func (s *GRPCServer) GenerateRandomString(ctx context.Context, request *pb.Rando
 		EncryptionString: response.KeyString,
 	}
 
-	logging.Debug().Msg("Successfully generated random key")
+	s.logger.Debug().Msg("Successfully generated random key")
 	return pbResponse, nil
 }

--- a/app/internal/domains/encryption/adapters/primary/grpc/server_test.go
+++ b/app/internal/domains/encryption/adapters/primary/grpc/server_test.go
@@ -1,0 +1,188 @@
+package grpc
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/ports/contracts"
+	pb "github.com/Anthony-Bible/password-exchange/app/pkg/pb/encryption"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// --- Stub LoggerPort ---
+
+type stubLogEvent struct{}
+
+func (stubLogEvent) Err(error) contracts.LogEvent             { return stubLogEvent{} }
+func (stubLogEvent) Str(string, string) contracts.LogEvent    { return stubLogEvent{} }
+func (stubLogEvent) Int(string, int) contracts.LogEvent       { return stubLogEvent{} }
+func (stubLogEvent) Int32(string, int32) contracts.LogEvent   { return stubLogEvent{} }
+func (stubLogEvent) Bool(string, bool) contracts.LogEvent     { return stubLogEvent{} }
+func (stubLogEvent) Dur(string, time.Duration) contracts.LogEvent { return stubLogEvent{} }
+func (stubLogEvent) Float64(string, float64) contracts.LogEvent   { return stubLogEvent{} }
+func (stubLogEvent) Msg(string)                                {}
+
+type stubLogger struct{}
+
+func (stubLogger) Debug() contracts.LogEvent { return stubLogEvent{} }
+func (stubLogger) Info() contracts.LogEvent  { return stubLogEvent{} }
+func (stubLogger) Warn() contracts.LogEvent  { return stubLogEvent{} }
+func (stubLogger) Error() contracts.LogEvent { return stubLogEvent{} }
+func (stubLogger) Fatal() contracts.LogEvent { return stubLogEvent{} }
+
+// --- Stub EncryptionServicePort ---
+
+type stubService struct {
+	encryptResp *contracts.EncryptionResponse
+	encryptErr  error
+	decryptResp *contracts.DecryptionResponse
+	decryptErr  error
+	randomResp  *contracts.RandomResponse
+	randomErr   error
+
+	lastEncryptReq contracts.EncryptionRequest
+	lastDecryptReq contracts.DecryptionRequest
+	lastRandomReq  contracts.RandomRequest
+}
+
+func (s *stubService) Encrypt(_ context.Context, req contracts.EncryptionRequest) (*contracts.EncryptionResponse, error) {
+	s.lastEncryptReq = req
+	return s.encryptResp, s.encryptErr
+}
+
+func (s *stubService) Decrypt(_ context.Context, req contracts.DecryptionRequest) (*contracts.DecryptionResponse, error) {
+	s.lastDecryptReq = req
+	return s.decryptResp, s.decryptErr
+}
+
+func (s *stubService) GenerateRandomKey(_ context.Context, req contracts.RandomRequest) (*contracts.RandomResponse, error) {
+	s.lastRandomReq = req
+	return s.randomResp, s.randomErr
+}
+
+func (s *stubService) GenerateID(_ context.Context) string { return "stub-id" }
+
+// --- Test harness ---
+
+func startTestServer(t *testing.T, svc *stubService) (pb.MessageServiceClient, func()) {
+	t.Helper()
+	lis := bufconn.Listen(1024 * 1024)
+	srv := grpc.NewServer()
+	adapter := NewGRPCServer(svc, "", stubLogger{})
+	pb.RegisterMessageServiceServer(srv, adapter)
+
+	serveErrCh := make(chan error, 1)
+	go func() {
+		serveErrCh <- srv.Serve(lis)
+	}()
+
+	conn, err := grpc.NewClient(
+		"passthrough://bufnet",
+		grpc.WithContextDialer(func(_ context.Context, _ string) (net.Conn, error) { return lis.Dial() }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+
+	cleanup := func() {
+		_ = conn.Close()
+		srv.Stop()
+		_ = lis.Close()
+		if serveErr := <-serveErrCh; serveErr != nil && !errors.Is(serveErr, grpc.ErrServerStopped) {
+			t.Errorf("gRPC Serve returned unexpected error: %v", serveErr)
+		}
+	}
+	return pb.NewMessageServiceClient(conn), cleanup
+}
+
+func TestEncryptMessage_Success(t *testing.T) {
+	svc := &stubService{
+		encryptResp: &contracts.EncryptionResponse{Ciphertext: []string{"cipher1", "cipher2"}},
+	}
+	client, cleanup := startTestServer(t, svc)
+	defer cleanup()
+
+	resp, err := client.EncryptMessage(context.Background(), &pb.EncryptedMessageRequest{
+		PlainText: []string{"hello", "world"},
+		Key:       []byte("key-bytes"),
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"cipher1", "cipher2"}, resp.GetCiphertext())
+	assert.Equal(t, []string{"hello", "world"}, svc.lastEncryptReq.Plaintext)
+	assert.Equal(t, []byte("key-bytes"), svc.lastEncryptReq.Key)
+}
+
+func TestEncryptMessage_Error(t *testing.T) {
+	svc := &stubService{encryptErr: errors.New("boom")}
+	client, cleanup := startTestServer(t, svc)
+	defer cleanup()
+
+	_, err := client.EncryptMessage(context.Background(), &pb.EncryptedMessageRequest{
+		PlainText: []string{"hi"},
+	})
+	assert.Error(t, err)
+}
+
+func TestDecryptMessage_Success(t *testing.T) {
+	svc := &stubService{
+		decryptResp: &contracts.DecryptionResponse{Plaintext: []string{"plain1"}},
+	}
+	client, cleanup := startTestServer(t, svc)
+	defer cleanup()
+
+	resp, err := client.DecryptMessage(context.Background(), &pb.DecryptedMessageRequest{
+		Ciphertext: []string{"cipher1"},
+		Key:        []byte("k"),
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"plain1"}, resp.GetPlaintext())
+	assert.Equal(t, []string{"cipher1"}, svc.lastDecryptReq.Ciphertext)
+	assert.Equal(t, []byte("k"), svc.lastDecryptReq.Key)
+}
+
+func TestDecryptMessage_Error(t *testing.T) {
+	svc := &stubService{decryptErr: errors.New("nope")}
+	client, cleanup := startTestServer(t, svc)
+	defer cleanup()
+
+	_, err := client.DecryptMessage(context.Background(), &pb.DecryptedMessageRequest{
+		Ciphertext: []string{"c"},
+	})
+	assert.Error(t, err)
+}
+
+func TestGenerateRandomString_Success(t *testing.T) {
+	var key contracts.EncryptionKey
+	for i := range key {
+		key[i] = byte(i)
+	}
+	svc := &stubService{
+		randomResp: &contracts.RandomResponse{Key: key, KeyString: "encoded-key"},
+	}
+	client, cleanup := startTestServer(t, svc)
+	defer cleanup()
+
+	resp, err := client.GenerateRandomString(context.Background(), &pb.Randomrequest{RandomLength: 32})
+
+	require.NoError(t, err)
+	assert.Equal(t, key.Bytes(), resp.GetEncryptionBytes())
+	assert.Equal(t, "encoded-key", resp.GetEncryptionString())
+	assert.Equal(t, int32(32), svc.lastRandomReq.Length)
+}
+
+func TestGenerateRandomString_Error(t *testing.T) {
+	svc := &stubService{randomErr: errors.New("rng failure")}
+	client, cleanup := startTestServer(t, svc)
+	defer cleanup()
+
+	_, err := client.GenerateRandomString(context.Background(), &pb.Randomrequest{RandomLength: 16})
+	assert.Error(t, err)
+}

--- a/app/internal/domains/encryption/adapters/secondary/logger/adapter.go
+++ b/app/internal/domains/encryption/adapters/secondary/logger/adapter.go
@@ -1,0 +1,81 @@
+package logger
+
+import (
+	"time"
+
+	"github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/ports/contracts"
+	"github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/ports/secondary"
+	"github.com/Anthony-Bible/password-exchange/app/internal/shared/logging"
+)
+
+// Adapter implements LoggerPort using the shared slog-based logging package
+type Adapter struct{}
+
+// NewAdapter creates a new logger adapter
+func NewAdapter() secondary.LoggerPort {
+	return &Adapter{}
+}
+
+func (a *Adapter) Debug() contracts.LogEvent {
+	return &Event{event: logging.Debug()}
+}
+
+func (a *Adapter) Info() contracts.LogEvent {
+	return &Event{event: logging.Info()}
+}
+
+func (a *Adapter) Warn() contracts.LogEvent {
+	return &Event{event: logging.Warn()}
+}
+
+func (a *Adapter) Error() contracts.LogEvent {
+	return &Event{event: logging.Error()}
+}
+
+func (a *Adapter) Fatal() contracts.LogEvent {
+	return &Event{event: logging.Fatal()}
+}
+
+// Event implements LogEvent for the shared logger
+type Event struct {
+	event *logging.Event
+}
+
+func (e *Event) Err(err error) contracts.LogEvent {
+	e.event = e.event.Err(err)
+	return e
+}
+
+func (e *Event) Str(key, value string) contracts.LogEvent {
+	e.event = e.event.Str(key, value)
+	return e
+}
+
+func (e *Event) Int(key string, value int) contracts.LogEvent {
+	e.event = e.event.Int(key, value)
+	return e
+}
+
+func (e *Event) Int32(key string, value int32) contracts.LogEvent {
+	e.event = e.event.Int32(key, value)
+	return e
+}
+
+func (e *Event) Bool(key string, value bool) contracts.LogEvent {
+	e.event = e.event.Bool(key, value)
+	return e
+}
+
+func (e *Event) Dur(key string, value time.Duration) contracts.LogEvent {
+	e.event = e.event.Dur(key, value)
+	return e
+}
+
+func (e *Event) Float64(key string, value float64) contracts.LogEvent {
+	e.event = e.event.Float64(key, value)
+	return e
+}
+
+func (e *Event) Msg(msg string) {
+	e.event.Msg(msg)
+}

--- a/app/internal/domains/encryption/adapters/secondary/memory/keygen.go
+++ b/app/internal/domains/encryption/adapters/secondary/memory/keygen.go
@@ -7,33 +7,36 @@ import (
 	"io"
 
 	"github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/domain"
-	"github.com/Anthony-Bible/password-exchange/app/internal/shared/logging"
+	"github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/ports/contracts"
+	"github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/ports/secondary"
 	"github.com/rs/xid"
 )
 
 // KeyGenerator implements the KeyGeneratorPort using in-memory operations
-type KeyGenerator struct{}
+type KeyGenerator struct {
+	logger secondary.LoggerPort
+}
 
 // NewKeyGenerator creates a new memory-based key generator
-func NewKeyGenerator() *KeyGenerator {
-	return &KeyGenerator{}
+func NewKeyGenerator(logger secondary.LoggerPort) *KeyGenerator {
+	return &KeyGenerator{logger: logger}
 }
 
 // GenerateKey generates a cryptographically secure random key
-func (g *KeyGenerator) GenerateKey(ctx context.Context, length int32) (domain.EncryptionKey, error) {
+func (g *KeyGenerator) GenerateKey(ctx context.Context, length int32) (contracts.EncryptionKey, error) {
 	if length != 32 {
-		logging.Error().Int32("length", length).Msg("Invalid key length requested")
-		return domain.EncryptionKey{}, domain.ErrInvalidKeyLength
+		g.logger.Error().Int32("length", length).Msg("Invalid key length requested")
+		return contracts.EncryptionKey{}, domain.ErrInvalidKeyLength
 	}
 
-	var key domain.EncryptionKey
+	var key contracts.EncryptionKey
 	_, err := io.ReadFull(rand.Reader, key[:])
 	if err != nil {
-		logging.Error().Err(err).Msg("Failed to generate random key")
-		return domain.EncryptionKey{}, fmt.Errorf("%w: %v", domain.ErrInsufficientRandomness, err)
+		g.logger.Error().Err(err).Msg("Failed to generate random key")
+		return contracts.EncryptionKey{}, fmt.Errorf("%w: %v", domain.ErrInsufficientRandomness, err)
 	}
 
-	logging.Debug().Msg("Successfully generated random key")
+	g.logger.Debug().Msg("Successfully generated random key")
 	return key, nil
 }
 
@@ -41,6 +44,6 @@ func (g *KeyGenerator) GenerateKey(ctx context.Context, length int32) (domain.En
 func (g *KeyGenerator) GenerateID(ctx context.Context) string {
 	guid := xid.New()
 	id := guid.String()
-	logging.Debug().Str("id", id).Msg("Generated unique ID")
+	g.logger.Debug().Str("id", id).Msg("Generated unique ID")
 	return id
 }

--- a/app/internal/domains/encryption/adapters/secondary/memory/keygen_test.go
+++ b/app/internal/domains/encryption/adapters/secondary/memory/keygen_test.go
@@ -1,0 +1,72 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/domain"
+	"github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/ports/contracts"
+)
+
+// mockLogEvent is a no-op LogEvent for tests
+type mockLogEvent struct{}
+
+func (m *mockLogEvent) Err(error) contracts.LogEvent              { return m }
+func (m *mockLogEvent) Str(string, string) contracts.LogEvent     { return m }
+func (m *mockLogEvent) Int(string, int) contracts.LogEvent        { return m }
+func (m *mockLogEvent) Int32(string, int32) contracts.LogEvent    { return m }
+func (m *mockLogEvent) Bool(string, bool) contracts.LogEvent      { return m }
+func (m *mockLogEvent) Dur(string, time.Duration) contracts.LogEvent { return m }
+func (m *mockLogEvent) Float64(string, float64) contracts.LogEvent   { return m }
+func (m *mockLogEvent) Msg(string)                                {}
+
+// mockLogger is a no-op LoggerPort for tests
+type mockLogger struct{}
+
+func (m *mockLogger) Debug() contracts.LogEvent { return &mockLogEvent{} }
+func (m *mockLogger) Info() contracts.LogEvent  { return &mockLogEvent{} }
+func (m *mockLogger) Warn() contracts.LogEvent  { return &mockLogEvent{} }
+func (m *mockLogger) Error() contracts.LogEvent { return &mockLogEvent{} }
+func (m *mockLogger) Fatal() contracts.LogEvent { return &mockLogEvent{} }
+
+func TestGenerateKey_Valid32Bytes(t *testing.T) {
+	g := NewKeyGenerator(&mockLogger{})
+	key, err := g.GenerateKey(context.Background(), 32)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(key.Bytes()) != 32 {
+		t.Fatalf("expected 32 bytes, got %d", len(key.Bytes()))
+	}
+	var zero contracts.EncryptionKey
+	if key == zero {
+		t.Fatal("generated key is all zero (vanishingly unlikely)")
+	}
+}
+
+func TestGenerateKey_InvalidLength(t *testing.T) {
+	g := NewKeyGenerator(&mockLogger{})
+	_, err := g.GenerateKey(context.Background(), 16)
+	if !errors.Is(err, domain.ErrInvalidKeyLength) {
+		t.Fatalf("expected ErrInvalidKeyLength, got %v", err)
+	}
+}
+
+func TestGenerateID_NonEmpty(t *testing.T) {
+	g := NewKeyGenerator(&mockLogger{})
+	id := g.GenerateID(context.Background())
+	if id == "" {
+		t.Fatal("expected non-empty id")
+	}
+}
+
+func TestGenerateID_Unique(t *testing.T) {
+	g := NewKeyGenerator(&mockLogger{})
+	id1 := g.GenerateID(context.Background())
+	id2 := g.GenerateID(context.Background())
+	if id1 == id2 {
+		t.Fatalf("expected unique ids, got %q twice", id1)
+	}
+}

--- a/app/internal/domains/encryption/adapters/secondary/viper/config.go
+++ b/app/internal/domains/encryption/adapters/secondary/viper/config.go
@@ -1,0 +1,86 @@
+// Package viper provides a Viper-backed implementation of the encryption
+// domain's ConfigPort, supplying gRPC bind address configuration.
+package viper
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/ports/secondary"
+	"github.com/spf13/viper"
+)
+
+// ErrInvalidListenAddress indicates the configured listen address is malformed.
+var ErrInvalidListenAddress = errors.New("invalid listen address")
+
+const (
+	keyHost = "encryption.host"
+	keyPort = "encryption.port"
+
+	defaultHost = "0.0.0.0"
+	defaultPort = 50051
+)
+
+// ViperConfigAdapter implements ConfigPort using Viper for both config-file
+// and environment-variable resolution. Env vars are picked up via Viper's
+// prefix + key-replacer machinery (configured in cmd/root.go at startup):
+// PASSWORDEXCHANGE_ENCRYPTION_HOST and PASSWORDEXCHANGE_ENCRYPTION_PORT map
+// to encryption.host and encryption.port respectively.
+//
+// Precedence (highest to lowest): explicit override (viper.Set) > env var >
+// config file > built-in default.
+type ViperConfigAdapter struct{}
+
+// NewViperConfigAdapter creates a new Viper-backed configuration adapter
+// and registers env-var bindings for the encryption listen address keys.
+func NewViperConfigAdapter() secondary.ConfigPort {
+	viper.BindEnv(keyHost)
+	viper.BindEnv(keyPort)
+	return &ViperConfigAdapter{}
+}
+
+// GetGRPCHost returns the host portion of the gRPC bind address.
+func (a *ViperConfigAdapter) GetGRPCHost() string {
+	if v := viper.GetString(keyHost); v != "" {
+		return v
+	}
+	return defaultHost
+}
+
+// GetGRPCPort returns the port portion of the gRPC bind address. If the
+// configured value is missing, unparseable, or non-positive, the built-in
+// default port is used.
+func (a *ViperConfigAdapter) GetGRPCPort() int {
+	if p := viper.GetInt(keyPort); p > 0 {
+		return p
+	}
+	return defaultPort
+}
+
+// GetListenAddress returns the full host:port bind string.
+func (a *ViperConfigAdapter) GetListenAddress() string {
+	return net.JoinHostPort(strings.TrimSpace(a.GetGRPCHost()), strconv.Itoa(a.GetGRPCPort()))
+}
+
+// ValidateListenAddress verifies host is non-empty and port is in 1..65535.
+func (a *ViperConfigAdapter) ValidateListenAddress() error {
+	host := strings.TrimSpace(a.GetGRPCHost())
+	port := a.GetGRPCPort()
+	if host == "" {
+		return fmt.Errorf("%w: host is empty", ErrInvalidListenAddress)
+	}
+	if port < 1 || port > 65535 {
+		return fmt.Errorf("%w: port %d out of range 1..65535", ErrInvalidListenAddress, port)
+	}
+	address := net.JoinHostPort(host, strconv.Itoa(port))
+	if _, _, err := net.SplitHostPort(address); err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidListenAddress, err)
+	}
+	if _, err := net.ResolveTCPAddr("tcp", address); err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidListenAddress, err)
+	}
+	return nil
+}

--- a/app/internal/domains/encryption/adapters/secondary/viper/config_test.go
+++ b/app/internal/domains/encryption/adapters/secondary/viper/config_test.go
@@ -1,0 +1,152 @@
+package viper
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+const (
+	envHost = "PASSWORDEXCHANGE_ENCRYPTION_HOST"
+	envPort = "PASSWORDEXCHANGE_ENCRYPTION_PORT"
+)
+
+// cleanState resets global viper and re-installs the env-binding configuration
+// that cmd/root.go normally applies at app startup (prefix, key replacer,
+// AutomaticEnv). It also clears any encryption env vars inherited from the
+// test runner so per-test t.Setenv calls drive behavior cleanly.
+func cleanState(t *testing.T) {
+	t.Helper()
+	viper.Reset()
+	viper.SetEnvPrefix("passwordexchange")
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.AutomaticEnv()
+	t.Setenv(envHost, "")
+	t.Setenv(envPort, "")
+	t.Cleanup(viper.Reset)
+}
+
+// seedConfig loads encryption.host/port from an in-memory YAML buffer, mimicking
+// values supplied via a real config file (Viper's "config" precedence tier).
+func seedConfig(t *testing.T, host string, port int) {
+	t.Helper()
+	viper.SetConfigType("yaml")
+	yaml := "encryption:\n  host: " + host + "\n  port: " + strconv.Itoa(port) + "\n"
+	if err := viper.ReadConfig(strings.NewReader(yaml)); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+}
+
+func TestViperConfigAdapter_Defaults(t *testing.T) {
+	cleanState(t)
+	a := NewViperConfigAdapter()
+	if got := a.GetGRPCHost(); got != "0.0.0.0" {
+		t.Errorf("default host: expected 0.0.0.0, got %q", got)
+	}
+	if got := a.GetGRPCPort(); got != 50051 {
+		t.Errorf("default port: expected 50051, got %d", got)
+	}
+	if got := a.GetListenAddress(); got != "0.0.0.0:50051" {
+		t.Errorf("default address: expected 0.0.0.0:50051, got %q", got)
+	}
+	if err := a.ValidateListenAddress(); err != nil {
+		t.Errorf("default address should validate, got %v", err)
+	}
+}
+
+func TestViperConfigAdapter_ConfigOverrides(t *testing.T) {
+	cleanState(t)
+	seedConfig(t, "127.0.0.1", 9090)
+	a := NewViperConfigAdapter()
+	if got := a.GetGRPCHost(); got != "127.0.0.1" {
+		t.Errorf("host: expected 127.0.0.1, got %q", got)
+	}
+	if got := a.GetGRPCPort(); got != 9090 {
+		t.Errorf("port: expected 9090, got %d", got)
+	}
+	if got := a.GetListenAddress(); got != "127.0.0.1:9090" {
+		t.Errorf("address: expected 127.0.0.1:9090, got %q", got)
+	}
+}
+
+func TestViperConfigAdapter_EnvOverridesConfig(t *testing.T) {
+	cleanState(t)
+	seedConfig(t, "127.0.0.1", 9090)
+	t.Setenv(envHost, "10.0.0.5")
+	t.Setenv(envPort, "31337")
+
+	a := NewViperConfigAdapter()
+	if got := a.GetGRPCHost(); got != "10.0.0.5" {
+		t.Errorf("env host should win over config; got %q", got)
+	}
+	if got := a.GetGRPCPort(); got != 31337 {
+		t.Errorf("env port should win over config; got %d", got)
+	}
+}
+
+func TestViperConfigAdapter_EnvOnly(t *testing.T) {
+	cleanState(t)
+	t.Setenv(envHost, "0.0.0.0")
+	t.Setenv(envPort, "60000")
+
+	a := NewViperConfigAdapter()
+	if got := a.GetListenAddress(); got != "0.0.0.0:60000" {
+		t.Errorf("env-only address: expected 0.0.0.0:60000, got %q", got)
+	}
+}
+
+func TestViperConfigAdapter_GetListenAddress_IPv6(t *testing.T) {
+	cleanState(t)
+	t.Setenv(envHost, "::1")
+	t.Setenv(envPort, "50052")
+
+	a := NewViperConfigAdapter()
+	if got := a.GetListenAddress(); got != "[::1]:50052" {
+		t.Errorf("ipv6 listen address: expected [::1]:50052, got %q", got)
+	}
+}
+
+func TestViperConfigAdapter_EnvPortBadFormatFallsBack(t *testing.T) {
+	cleanState(t)
+	t.Setenv(envPort, "not-a-number")
+	a := NewViperConfigAdapter()
+	if got := a.GetGRPCPort(); got != defaultPort {
+		t.Errorf("invalid env port should fall back to default %d, got %d", defaultPort, got)
+	}
+}
+
+func TestViperConfigAdapter_ValidateListenAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		host    string
+		port    int
+		wantErr bool
+	}{
+		{"valid", "127.0.0.1", 8080, false},
+		{"valid ipv6", "::1", 8080, false},
+		{"host whitespace", "   ", 8080, true},
+		{"host unparsable", "bad host", 8080, true},
+		{"port too high", "127.0.0.1", 70000, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cleanState(t)
+			viper.Set("encryption.host", tt.host)
+			viper.Set("encryption.port", tt.port)
+			a := NewViperConfigAdapter()
+			err := a.ValidateListenAddress()
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantErr && err != nil && !errors.Is(err, ErrInvalidListenAddress) {
+				t.Fatalf("expected ErrInvalidListenAddress, got %v", err)
+			}
+		})
+	}
+}

--- a/app/internal/domains/encryption/domain/entities.go
+++ b/app/internal/domains/encryption/domain/entities.go
@@ -1,58 +1,17 @@
 package domain
 
-import (
-	"context"
-	"encoding/base64"
+import "github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/ports/contracts"
+
+// These aliases preserve backward compatibility for callers that import the
+// domain package directly (e.g. `domain.EncryptionRequest{}`) while the
+// canonical type definitions live in the contracts package.
+type (
+	EncryptionKey      = contracts.EncryptionKey
+	EncryptionRequest  = contracts.EncryptionRequest
+	EncryptionResponse = contracts.EncryptionResponse
+	DecryptionRequest  = contracts.DecryptionRequest
+	DecryptionResponse = contracts.DecryptionResponse
+	RandomRequest      = contracts.RandomRequest
+	RandomResponse     = contracts.RandomResponse
+	KeyGenerator       = contracts.KeyGenerator
 )
-
-// EncryptionKey represents a 32-byte encryption key
-type EncryptionKey [32]byte
-
-// String returns the base64 URL-encoded representation of the key
-func (k EncryptionKey) String() string {
-	return base64.URLEncoding.EncodeToString(k[:])
-}
-
-// Bytes returns the raw bytes of the key
-func (k EncryptionKey) Bytes() []byte {
-	return k[:]
-}
-
-// EncryptionRequest represents a request to encrypt plaintext
-type EncryptionRequest struct {
-	Plaintext []string
-	Key       []byte
-}
-
-// EncryptionResponse represents the result of encryption
-type EncryptionResponse struct {
-	Ciphertext []string
-}
-
-// DecryptionRequest represents a request to decrypt ciphertext
-type DecryptionRequest struct {
-	Ciphertext []string
-	Key        []byte
-}
-
-// DecryptionResponse represents the result of decryption
-type DecryptionResponse struct {
-	Plaintext []string
-}
-
-// RandomRequest represents a request for random key generation
-type RandomRequest struct {
-	Length int32
-}
-
-// RandomResponse represents the result of random key generation
-type RandomResponse struct {
-	Key       EncryptionKey
-	KeyString string
-}
-
-// KeyGenerator defines the interface for generating encryption keys
-type KeyGenerator interface {
-	GenerateKey(ctx context.Context, length int32) (EncryptionKey, error)
-	GenerateID(ctx context.Context) string
-}

--- a/app/internal/domains/encryption/domain/mocks_test.go
+++ b/app/internal/domains/encryption/domain/mocks_test.go
@@ -1,0 +1,60 @@
+package domain
+
+import (
+	"context"
+	"time"
+
+	"github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/ports/contracts"
+	"github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/ports/secondary"
+)
+
+// mockEvent is a no-op LogEvent used in tests. All chain methods return the
+// receiver so fluent calls compile and execute without side-effects.
+type mockEvent struct{}
+
+func (m *mockEvent) Err(error) contracts.LogEvent              { return m }
+func (m *mockEvent) Str(string, string) contracts.LogEvent     { return m }
+func (m *mockEvent) Int(string, int) contracts.LogEvent        { return m }
+func (m *mockEvent) Int32(string, int32) contracts.LogEvent    { return m }
+func (m *mockEvent) Bool(string, bool) contracts.LogEvent      { return m }
+func (m *mockEvent) Dur(string, time.Duration) contracts.LogEvent { return m }
+func (m *mockEvent) Float64(string, float64) contracts.LogEvent { return m }
+func (m *mockEvent) Msg(string)                                {}
+
+// mockLogger implements secondary.LoggerPort for tests.
+type mockLogger struct{}
+
+func (m *mockLogger) Debug() contracts.LogEvent { return &mockEvent{} }
+func (m *mockLogger) Info() contracts.LogEvent  { return &mockEvent{} }
+func (m *mockLogger) Warn() contracts.LogEvent  { return &mockEvent{} }
+func (m *mockLogger) Error() contracts.LogEvent { return &mockEvent{} }
+func (m *mockLogger) Fatal() contracts.LogEvent { return &mockEvent{} }
+
+// Ensure mockLogger satisfies the port interface at compile time.
+var _ secondary.LoggerPort = (*mockLogger)(nil)
+
+// mockKeyGen implements contracts.KeyGenerator with configurable behavior.
+type mockKeyGen struct {
+	GenerateKeyFunc func(ctx context.Context, length int32) (contracts.EncryptionKey, error)
+	GenerateIDFunc  func(ctx context.Context) string
+}
+
+func (m *mockKeyGen) GenerateKey(ctx context.Context, length int32) (contracts.EncryptionKey, error) {
+	if m.GenerateKeyFunc != nil {
+		return m.GenerateKeyFunc(ctx, length)
+	}
+	var k contracts.EncryptionKey
+	for i := range k {
+		k[i] = 0xAA
+	}
+	return k, nil
+}
+
+func (m *mockKeyGen) GenerateID(ctx context.Context) string {
+	if m.GenerateIDFunc != nil {
+		return m.GenerateIDFunc(ctx)
+	}
+	return "fixed-id-123"
+}
+
+var _ contracts.KeyGenerator = (*mockKeyGen)(nil)

--- a/app/internal/domains/encryption/domain/roundtrip_test.go
+++ b/app/internal/domains/encryption/domain/roundtrip_test.go
@@ -1,0 +1,137 @@
+package domain
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"testing"
+
+	"github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/ports/contracts"
+)
+
+func newTestService() *EncryptionService {
+	return NewEncryptionService(&mockKeyGen{}, &mockLogger{})
+}
+
+func randKey(t *testing.T) []byte {
+	t.Helper()
+	k := make([]byte, 32)
+	if _, err := rand.Read(k); err != nil {
+		t.Fatalf("rand.Read: %v", err)
+	}
+	return k
+}
+
+func TestRoundtrip_RandomKey_PreservesPlaintext(t *testing.T) {
+	svc := newTestService()
+	ctx := context.Background()
+
+	lengths := []int{1, 2, 7, 16, 31, 32, 33, 64, 128, 4096}
+	plaintexts := make([]string, 0, len(lengths))
+	for i, n := range lengths {
+		buf := make([]byte, n)
+		if _, err := rand.Read(buf); err != nil {
+			t.Fatalf("rand: %v", err)
+		}
+		// include some unicode in one entry
+		if i == 3 {
+			plaintexts = append(plaintexts, "héllo 世界 🔒")
+			continue
+		}
+		plaintexts = append(plaintexts, string(buf))
+	}
+
+	key := randKey(t)
+	encResp, err := svc.Encrypt(ctx, contracts.EncryptionRequest{Plaintext: plaintexts, Key: key})
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	if len(encResp.Ciphertext) != len(plaintexts) {
+		t.Fatalf("expected %d ciphertexts got %d", len(plaintexts), len(encResp.Ciphertext))
+	}
+
+	decResp, err := svc.Decrypt(ctx, contracts.DecryptionRequest{Ciphertext: encResp.Ciphertext, Key: key})
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+	if len(decResp.Plaintext) != len(plaintexts) {
+		t.Fatalf("expected %d plaintexts got %d", len(plaintexts), len(decResp.Plaintext))
+	}
+
+	for i, encoded := range decResp.Plaintext {
+		raw, err := base64.URLEncoding.DecodeString(encoded)
+		if err != nil {
+			t.Fatalf("base64 decode plaintext[%d]: %v", i, err)
+		}
+		if string(raw) != plaintexts[i] {
+			t.Errorf("plaintext[%d] mismatch: got %q want %q", i, string(raw), plaintexts[i])
+		}
+	}
+}
+
+// TestDecrypt_StoredWireFormat_RemainsCompatible pins the on-the-wire ciphertext
+// format: base64.URLEncoding(nonce || gcm-sealed). Breaking this test means
+// ciphertexts already stored in the database become unreadable — i.e. this is a
+// backwards-compatibility guarantee, not an internal implementation detail.
+func TestDecrypt_StoredWireFormat_RemainsCompatible(t *testing.T) {
+	// Hard-coded 32-byte key.
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i)
+	}
+	plaintext := []byte("hello world")
+
+	// Build ciphertext using a fixed all-zero nonce so we exercise the exact
+	// wire format produced by the service.
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		t.Fatalf("aes.NewCipher: %v", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		t.Fatalf("cipher.NewGCM: %v", err)
+	}
+	nonce := make([]byte, gcm.NonceSize()) // 12 zero bytes
+	sealed := gcm.Seal(nonce, nonce, plaintext, nil)
+	encoded := base64.URLEncoding.EncodeToString(sealed)
+
+	svc := newTestService()
+	resp, err := svc.Decrypt(context.Background(), contracts.DecryptionRequest{
+		Ciphertext: []string{encoded},
+		Key:        key,
+	})
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+	if len(resp.Plaintext) != 1 {
+		t.Fatalf("expected 1 plaintext got %d", len(resp.Plaintext))
+	}
+	want := base64.URLEncoding.EncodeToString(plaintext)
+	if resp.Plaintext[0] != want {
+		t.Errorf("wire format compatibility broken: got %q want %q", resp.Plaintext[0], want)
+	}
+}
+
+func TestRoundtrip_WrongKey_Fails(t *testing.T) {
+	svc := newTestService()
+	ctx := context.Background()
+
+	key1 := randKey(t)
+	key2 := randKey(t)
+
+	enc, err := svc.Encrypt(ctx, contracts.EncryptionRequest{Plaintext: []string{"secret"}, Key: key1})
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+
+	_, err = svc.Decrypt(ctx, contracts.DecryptionRequest{Ciphertext: enc.Ciphertext, Key: key2})
+	if err == nil {
+		t.Fatalf("expected decryption to fail with wrong key")
+	}
+	if !errors.Is(err, ErrDecryptionFailed) {
+		t.Errorf("expected ErrDecryptionFailed, got %v", err)
+	}
+}

--- a/app/internal/domains/encryption/domain/service.go
+++ b/app/internal/domains/encryption/domain/service.go
@@ -9,48 +9,52 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/Anthony-Bible/password-exchange/app/internal/shared/logging"
+	"github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/ports/contracts"
+	"github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/ports/secondary"
 )
 
-// EncryptionService provides cryptographic operations
+// EncryptionService provides cryptographic operations.
 type EncryptionService struct {
-	keyGenerator KeyGenerator
+	keyGenerator contracts.KeyGenerator
+	logger       secondary.LoggerPort
 }
 
-// NewEncryptionService creates a new encryption service
-func NewEncryptionService(keyGenerator KeyGenerator) *EncryptionService {
+// NewEncryptionService creates a new encryption service wired with the supplied
+// key generator and logger port.
+func NewEncryptionService(keyGenerator contracts.KeyGenerator, logger secondary.LoggerPort) *EncryptionService {
 	return &EncryptionService{
 		keyGenerator: keyGenerator,
+		logger:       logger,
 	}
 }
 
-// Encrypt encrypts multiple plaintext messages using AES-GCM
-func (s *EncryptionService) Encrypt(ctx context.Context, req EncryptionRequest) (*EncryptionResponse, error) {
+// Encrypt encrypts multiple plaintext messages using AES-GCM.
+func (s *EncryptionService) Encrypt(ctx context.Context, req contracts.EncryptionRequest) (*contracts.EncryptionResponse, error) {
 	if len(req.Key) != 32 {
-		logging.Error().Int("keyLength", len(req.Key)).Msg("Invalid key length for encryption")
+		s.logger.Error().Int("keyLength", len(req.Key)).Msg("Invalid key length for encryption")
 		return nil, ErrInvalidKeyLength
 	}
 
 	block, err := aes.NewCipher(req.Key)
 	if err != nil {
-		logging.Error().Err(err).Msg("Failed to create AES cipher")
+		s.logger.Error().Err(err).Msg("Failed to create AES cipher")
 		return nil, fmt.Errorf("%w: %v", ErrCipherCreationFailed, err)
 	}
 
 	gcm, err := cipher.NewGCM(block)
 	if err != nil {
-		logging.Error().Err(err).Msg("Failed to create GCM")
+		s.logger.Error().Err(err).Msg("Failed to create GCM")
 		return nil, fmt.Errorf("%w: %v", ErrGCMCreationFailed, err)
 	}
 
-	response := &EncryptionResponse{
+	response := &contracts.EncryptionResponse{
 		Ciphertext: make([]string, 0, len(req.Plaintext)),
 	}
 
 	for _, plaintext := range req.Plaintext {
 		nonce := make([]byte, gcm.NonceSize())
 		if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
-			logging.Error().Err(err).Msg("Failed to generate nonce")
+			s.logger.Error().Err(err).Msg("Failed to generate nonce")
 			return nil, fmt.Errorf("%w: %v", ErrInsufficientRandomness, err)
 		}
 
@@ -59,42 +63,42 @@ func (s *EncryptionService) Encrypt(ctx context.Context, req EncryptionRequest) 
 		response.Ciphertext = append(response.Ciphertext, encodedCiphertext)
 	}
 
-	logging.Debug().Int("plaintextCount", len(req.Plaintext)).Msg("Successfully encrypted messages")
+	s.logger.Debug().Int("plaintextCount", len(req.Plaintext)).Msg("Successfully encrypted messages")
 	return response, nil
 }
 
-// Decrypt decrypts multiple ciphertext messages using AES-GCM
-func (s *EncryptionService) Decrypt(ctx context.Context, req DecryptionRequest) (*DecryptionResponse, error) {
+// Decrypt decrypts multiple ciphertext messages using AES-GCM.
+func (s *EncryptionService) Decrypt(ctx context.Context, req contracts.DecryptionRequest) (*contracts.DecryptionResponse, error) {
 	if len(req.Key) != 32 {
-		logging.Error().Int("keyLength", len(req.Key)).Msg("Invalid key length for decryption")
+		s.logger.Error().Int("keyLength", len(req.Key)).Msg("Invalid key length for decryption")
 		return nil, ErrInvalidKeyLength
 	}
 
 	block, err := aes.NewCipher(req.Key)
 	if err != nil {
-		logging.Error().Err(err).Msg("Failed to create AES cipher")
+		s.logger.Error().Err(err).Msg("Failed to create AES cipher")
 		return nil, fmt.Errorf("%w: %v", ErrCipherCreationFailed, err)
 	}
 
 	gcm, err := cipher.NewGCM(block)
 	if err != nil {
-		logging.Error().Err(err).Msg("Failed to create GCM")
+		s.logger.Error().Err(err).Msg("Failed to create GCM")
 		return nil, fmt.Errorf("%w: %v", ErrGCMCreationFailed, err)
 	}
 
-	response := &DecryptionResponse{
+	response := &contracts.DecryptionResponse{
 		Plaintext: make([]string, 0, len(req.Ciphertext)),
 	}
 
 	for _, encodedCiphertext := range req.Ciphertext {
 		ciphertext, err := base64.URLEncoding.DecodeString(encodedCiphertext)
 		if err != nil {
-			logging.Error().Err(err).Str("ciphertext", encodedCiphertext).Msg("Failed to decode base64 ciphertext")
+			s.logger.Error().Err(err).Str("ciphertext", encodedCiphertext).Msg("Failed to decode base64 ciphertext")
 			return nil, fmt.Errorf("%w: %v", ErrBase64DecodingFailed, err)
 		}
 
 		if len(ciphertext) < gcm.NonceSize() {
-			logging.Error().Int("ciphertextLength", len(ciphertext)).Int("nonceSize", gcm.NonceSize()).Msg("Ciphertext too short")
+			s.logger.Error().Int("ciphertextLength", len(ciphertext)).Int("nonceSize", gcm.NonceSize()).Msg("Ciphertext too short")
 			return nil, ErrInvalidCiphertext
 		}
 
@@ -103,7 +107,7 @@ func (s *EncryptionService) Decrypt(ctx context.Context, req DecryptionRequest) 
 
 		plaintext, err := gcm.Open(nil, nonce, encryptedData, nil)
 		if err != nil {
-			logging.Error().Err(err).Msg("Failed to decrypt message")
+			s.logger.Error().Err(err).Msg("Failed to decrypt message")
 			return nil, fmt.Errorf("%w: %v", ErrDecryptionFailed, err)
 		}
 
@@ -111,33 +115,33 @@ func (s *EncryptionService) Decrypt(ctx context.Context, req DecryptionRequest) 
 		response.Plaintext = append(response.Plaintext, encodedPlaintext)
 	}
 
-	logging.Debug().Int("ciphertextCount", len(req.Ciphertext)).Msg("Successfully decrypted messages")
+	s.logger.Debug().Int("ciphertextCount", len(req.Ciphertext)).Msg("Successfully decrypted messages")
 	return response, nil
 }
 
-// GenerateRandomKey generates a new random encryption key
-func (s *EncryptionService) GenerateRandomKey(ctx context.Context, req RandomRequest) (*RandomResponse, error) {
+// GenerateRandomKey generates a new random encryption key.
+func (s *EncryptionService) GenerateRandomKey(ctx context.Context, req contracts.RandomRequest) (*contracts.RandomResponse, error) {
 	if req.Length != 32 {
-		logging.Error().Int32("length", req.Length).Msg("Invalid key length requested")
+		s.logger.Error().Int32("length", req.Length).Msg("Invalid key length requested")
 		return nil, ErrInvalidKeyLength
 	}
 
 	key, err := s.keyGenerator.GenerateKey(ctx, req.Length)
 	if err != nil {
-		logging.Error().Err(err).Msg("Failed to generate random key")
+		s.logger.Error().Err(err).Msg("Failed to generate random key")
 		return nil, err
 	}
 
-	response := &RandomResponse{
+	response := &contracts.RandomResponse{
 		Key:       key,
 		KeyString: key.String(),
 	}
 
-	logging.Debug().Msg("Successfully generated random key")
+	s.logger.Debug().Msg("Successfully generated random key")
 	return response, nil
 }
 
-// GenerateID generates a new unique identifier
+// GenerateID generates a new unique identifier.
 func (s *EncryptionService) GenerateID(ctx context.Context) string {
 	return s.keyGenerator.GenerateID(ctx)
 }

--- a/app/internal/domains/encryption/domain/service_test.go
+++ b/app/internal/domains/encryption/domain/service_test.go
@@ -1,0 +1,178 @@
+package domain
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"testing"
+
+	"github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/ports/contracts"
+)
+
+func TestEncrypt_Success(t *testing.T) {
+	svc := newTestService()
+	key := make([]byte, 32)
+	resp, err := svc.Encrypt(context.Background(), contracts.EncryptionRequest{
+		Plaintext: []string{"a", "bb"},
+		Key:       key,
+	})
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	if len(resp.Ciphertext) != 2 {
+		t.Fatalf("expected 2 ciphertexts got %d", len(resp.Ciphertext))
+	}
+	for i, c := range resp.Ciphertext {
+		if c == "" {
+			t.Errorf("ciphertext[%d] empty", i)
+		}
+	}
+}
+
+func TestEncrypt_InvalidKeyLength(t *testing.T) {
+	svc := newTestService()
+	_, err := svc.Encrypt(context.Background(), contracts.EncryptionRequest{
+		Plaintext: []string{"hi"},
+		Key:       make([]byte, 16),
+	})
+	if !errors.Is(err, ErrInvalidKeyLength) {
+		t.Errorf("expected ErrInvalidKeyLength got %v", err)
+	}
+}
+
+func TestEncrypt_EmptyPlaintextSlice(t *testing.T) {
+	svc := newTestService()
+	resp, err := svc.Encrypt(context.Background(), contracts.EncryptionRequest{
+		Plaintext: []string{},
+		Key:       make([]byte, 32),
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(resp.Ciphertext) != 0 {
+		t.Errorf("expected empty ciphertext slice got %d entries", len(resp.Ciphertext))
+	}
+}
+
+func TestDecrypt_Errors(t *testing.T) {
+	svc := newTestService()
+	ctx := context.Background()
+
+	enc, err := svc.Encrypt(ctx, contracts.EncryptionRequest{
+		Plaintext: []string{"secret"},
+		Key:       make([]byte, 32),
+	})
+	if err != nil {
+		t.Fatalf("setup Encrypt: %v", err)
+	}
+	raw, err := base64.URLEncoding.DecodeString(enc.Ciphertext[0])
+	if err != nil {
+		t.Fatalf("setup base64 decode: %v", err)
+	}
+	raw[len(raw)/2] ^= 0x01
+	tampered := base64.URLEncoding.EncodeToString(raw)
+
+	tooShortForNonce := base64.URLEncoding.EncodeToString([]byte{1, 2, 3})
+
+	tests := []struct {
+		name       string
+		ciphertext []string
+		key        []byte
+		wantErr    error
+	}{
+		{
+			name:       "invalid key length",
+			ciphertext: []string{"abc"},
+			key:        make([]byte, 8),
+			wantErr:    ErrInvalidKeyLength,
+		},
+		{
+			name:       "malformed base64",
+			ciphertext: []string{"!!!not_base64!!!"},
+			key:        make([]byte, 32),
+			wantErr:    ErrBase64DecodingFailed,
+		},
+		{
+			name:       "ciphertext shorter than nonce",
+			ciphertext: []string{tooShortForNonce},
+			key:        make([]byte, 32),
+			wantErr:    ErrInvalidCiphertext,
+		},
+		{
+			name:       "tampered ciphertext fails authentication",
+			ciphertext: []string{tampered},
+			key:        make([]byte, 32),
+			wantErr:    ErrDecryptionFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := svc.Decrypt(ctx, contracts.DecryptionRequest{
+				Ciphertext: tt.ciphertext,
+				Key:        tt.key,
+			})
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("expected %v, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestGenerateRandomKey_Success(t *testing.T) {
+	var wantKey contracts.EncryptionKey
+	for i := range wantKey {
+		wantKey[i] = 0x42
+	}
+	kg := &mockKeyGen{
+		GenerateKeyFunc: func(ctx context.Context, length int32) (contracts.EncryptionKey, error) {
+			if length != 32 {
+				t.Errorf("expected length 32 got %d", length)
+			}
+			return wantKey, nil
+		},
+	}
+	svc := NewEncryptionService(kg, &mockLogger{})
+	resp, err := svc.GenerateRandomKey(context.Background(), contracts.RandomRequest{Length: 32})
+	if err != nil {
+		t.Fatalf("GenerateRandomKey: %v", err)
+	}
+	if resp.Key != wantKey {
+		t.Errorf("key mismatch")
+	}
+	if resp.KeyString != wantKey.String() {
+		t.Errorf("keystring mismatch: got %q want %q", resp.KeyString, wantKey.String())
+	}
+}
+
+func TestGenerateRandomKey_InvalidLength(t *testing.T) {
+	svc := newTestService()
+	_, err := svc.GenerateRandomKey(context.Background(), contracts.RandomRequest{Length: 16})
+	if !errors.Is(err, ErrInvalidKeyLength) {
+		t.Errorf("expected ErrInvalidKeyLength got %v", err)
+	}
+}
+
+func TestGenerateRandomKey_KeygenError(t *testing.T) {
+	sentinel := errors.New("keygen boom")
+	kg := &mockKeyGen{
+		GenerateKeyFunc: func(ctx context.Context, length int32) (contracts.EncryptionKey, error) {
+			return contracts.EncryptionKey{}, sentinel
+		},
+	}
+	svc := NewEncryptionService(kg, &mockLogger{})
+	_, err := svc.GenerateRandomKey(context.Background(), contracts.RandomRequest{Length: 32})
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected sentinel error got %v", err)
+	}
+}
+
+func TestGenerateID_Delegates(t *testing.T) {
+	kg := &mockKeyGen{
+		GenerateIDFunc: func(ctx context.Context) string { return "delegated-id" },
+	}
+	svc := NewEncryptionService(kg, &mockLogger{})
+	if got := svc.GenerateID(context.Background()); got != "delegated-id" {
+		t.Errorf("got %q want %q", got, "delegated-id")
+	}
+}

--- a/app/internal/domains/encryption/ports/contracts/types.go
+++ b/app/internal/domains/encryption/ports/contracts/types.go
@@ -1,0 +1,149 @@
+// Package contracts defines shared data types and interfaces used across the
+// encryption domain's layers. Centralizing these types here prevents import
+// cycles between domain, ports, and adapters.
+package contracts
+
+import (
+	"context"
+	"encoding/base64"
+	"time"
+)
+
+// EncryptionKey represents a 32-byte encryption key.
+type EncryptionKey [32]byte
+
+// String returns the base64 URL-encoded representation of the key.
+func (k EncryptionKey) String() string {
+	return base64.URLEncoding.EncodeToString(k[:])
+}
+
+// Bytes returns the raw bytes of the key.
+func (k EncryptionKey) Bytes() []byte {
+	return k[:]
+}
+
+// EncryptionRequest represents a request to encrypt plaintext.
+type EncryptionRequest struct {
+	Plaintext []string
+	Key       []byte
+}
+
+// EncryptionResponse represents the result of encryption.
+type EncryptionResponse struct {
+	Ciphertext []string
+}
+
+// DecryptionRequest represents a request to decrypt ciphertext.
+type DecryptionRequest struct {
+	Ciphertext []string
+	Key        []byte
+}
+
+// DecryptionResponse represents the result of decryption.
+type DecryptionResponse struct {
+	Plaintext []string
+}
+
+// RandomRequest represents a request for random key generation.
+type RandomRequest struct {
+	Length int32
+}
+
+// RandomResponse represents the result of random key generation.
+type RandomResponse struct {
+	Key       EncryptionKey
+	KeyString string
+}
+
+// KeyGenerator defines the interface for generating encryption keys and unique IDs.
+type KeyGenerator interface {
+	// GenerateKey generates a cryptographically secure random key of the specified length.
+	GenerateKey(ctx context.Context, length int32) (EncryptionKey, error)
+
+	// GenerateID generates a unique identifier.
+	GenerateID(ctx context.Context) string
+}
+
+// LogEvent represents a structured logging event that can be enriched with contextual data.
+// This interface follows a fluent API pattern, allowing method chaining to add various
+// types of contextual information before finalizing the log entry. This abstraction
+// allows the encryption domain to remain independent of specific logging implementations.
+type LogEvent interface {
+	// Err adds an error to the log event.
+	// The error will be formatted and included in the log output.
+	//
+	// Parameters:
+	//   - err: The error to log (can be nil)
+	//
+	// Returns:
+	//   - The LogEvent for method chaining
+	Err(error) LogEvent
+
+	// Str adds a string key-value pair to the log event.
+	//
+	// Parameters:
+	//   - key: The field name
+	//   - value: The string value
+	//
+	// Returns:
+	//   - The LogEvent for method chaining
+	Str(string, string) LogEvent
+
+	// Int adds an integer key-value pair to the log event.
+	//
+	// Parameters:
+	//   - key: The field name
+	//   - value: The integer value
+	//
+	// Returns:
+	//   - The LogEvent for method chaining
+	Int(string, int) LogEvent
+
+	// Int32 adds an int32 key-value pair to the log event.
+	//
+	// Parameters:
+	//   - key: The field name
+	//   - value: The int32 value
+	//
+	// Returns:
+	//   - The LogEvent for method chaining
+	Int32(string, int32) LogEvent
+
+	// Bool adds a boolean key-value pair to the log event.
+	//
+	// Parameters:
+	//   - key: The field name
+	//   - value: The boolean value
+	//
+	// Returns:
+	//   - The LogEvent for method chaining
+	Bool(string, bool) LogEvent
+
+	// Dur adds a duration key-value pair to the log event.
+	// The duration is typically formatted in a human-readable way.
+	//
+	// Parameters:
+	//   - key: The field name
+	//   - value: The duration value
+	//
+	// Returns:
+	//   - The LogEvent for method chaining
+	Dur(string, time.Duration) LogEvent
+
+	// Float64 adds a float64 key-value pair to the log event.
+	//
+	// Parameters:
+	//   - key: The field name
+	//   - value: The float64 value
+	//
+	// Returns:
+	//   - The LogEvent for method chaining
+	Float64(string, float64) LogEvent
+
+	// Msg finalizes the log event with a message and writes it to the log.
+	// This method should be called last in the chain.
+	//
+	// Parameters:
+	//   - message: The log message describing the event
+	Msg(string)
+}

--- a/app/internal/domains/encryption/ports/primary/service.go
+++ b/app/internal/domains/encryption/ports/primary/service.go
@@ -2,21 +2,21 @@ package primary
 
 import (
 	"context"
-	
-	"github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/domain"
+
+	"github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/ports/contracts"
 )
 
 // EncryptionServicePort defines the primary port for encryption operations
 type EncryptionServicePort interface {
 	// Encrypt encrypts multiple plaintext messages
-	Encrypt(ctx context.Context, req domain.EncryptionRequest) (*domain.EncryptionResponse, error)
-	
+	Encrypt(ctx context.Context, req contracts.EncryptionRequest) (*contracts.EncryptionResponse, error)
+
 	// Decrypt decrypts multiple ciphertext messages
-	Decrypt(ctx context.Context, req domain.DecryptionRequest) (*domain.DecryptionResponse, error)
-	
+	Decrypt(ctx context.Context, req contracts.DecryptionRequest) (*contracts.DecryptionResponse, error)
+
 	// GenerateRandomKey generates a new random encryption key
-	GenerateRandomKey(ctx context.Context, req domain.RandomRequest) (*domain.RandomResponse, error)
-	
+	GenerateRandomKey(ctx context.Context, req contracts.RandomRequest) (*contracts.RandomResponse, error)
+
 	// GenerateID generates a new unique identifier
 	GenerateID(ctx context.Context) string
 }

--- a/app/internal/domains/encryption/ports/secondary/config.go
+++ b/app/internal/domains/encryption/ports/secondary/config.go
@@ -1,0 +1,20 @@
+package secondary
+
+// ConfigPort defines the secondary port for accessing encryption service configuration.
+// Implementations supply gRPC bind addresses and related networking parameters.
+type ConfigPort interface {
+	// GetListenAddress returns the full host:port string the gRPC server should bind to.
+	// Defaults to "0.0.0.0:50051".
+	GetListenAddress() string
+
+	// GetGRPCHost returns the host portion of the gRPC bind address.
+	// Defaults to "0.0.0.0".
+	GetGRPCHost() string
+
+	// GetGRPCPort returns the port portion of the gRPC bind address.
+	// Defaults to 50051.
+	GetGRPCPort() int
+
+	// ValidateListenAddress verifies that the configured listen address is well-formed.
+	ValidateListenAddress() error
+}

--- a/app/internal/domains/encryption/ports/secondary/keygen.go
+++ b/app/internal/domains/encryption/ports/secondary/keygen.go
@@ -1,16 +1,11 @@
 package secondary
 
 import (
-	"context"
-	
-	"github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/domain"
+	"github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/ports/contracts"
 )
 
-// KeyGeneratorPort defines the secondary port for key generation operations
-type KeyGeneratorPort interface {
-	// GenerateKey generates a cryptographically secure random key of the specified length
-	GenerateKey(ctx context.Context, length int32) (domain.EncryptionKey, error)
-	
-	// GenerateID generates a unique identifier
-	GenerateID(ctx context.Context) string
-}
+// KeyGeneratorPort is an alias for contracts.KeyGenerator. The contracts
+// package owns the canonical interface; this alias preserves the
+// hexagonal-conventional "*Port" name without introducing a parallel
+// interface that could drift over time.
+type KeyGeneratorPort = contracts.KeyGenerator

--- a/app/internal/domains/encryption/ports/secondary/logger.go
+++ b/app/internal/domains/encryption/ports/secondary/logger.go
@@ -1,0 +1,24 @@
+package secondary
+
+import "github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/ports/contracts"
+
+// LoggerPort defines the secondary port for structured logging in the encryption domain.
+// Implementations adapt a specific logging library to the domain's needs without
+// leaking that library's types into the domain layer.
+type LoggerPort interface {
+	// Debug starts a new log event at debug level.
+	Debug() contracts.LogEvent
+
+	// Info starts a new log event at info level.
+	Info() contracts.LogEvent
+
+	// Warn starts a new log event at warn level.
+	Warn() contracts.LogEvent
+
+	// Error starts a new log event at error level.
+	Error() contracts.LogEvent
+
+	// Fatal starts a new log event at fatal severity. After Msg is called on
+	// the returned LogEvent, the process terminates via os.Exit(1).
+	Fatal() contracts.LogEvent
+}


### PR DESCRIPTION
Mirror the notification domain template to make encryption fully hexagonal-compliant:
- Extract DTOs and shared interfaces into ports/contracts/types.go
- Add LoggerPort and ConfigPort secondary ports; inject via constructors
- Remove direct shared/logging imports from domain and non-logger adapters
- Add slog-backed logger adapter and viper-backed config adapter
- Source listen address from ConfigPort instead of hardcoding 0.0.0.0:50051
- Collapse domain/entities.go to type aliases for backward-compat
- Add comprehensive unit tests including AES-GCM wire-format guard
  (roundtrip + fixed-ciphertext) to prove existing database ciphertext
  remains decryptable