### PR TITLE
refactor(logging): back shared logging with Anthony-Bible/Logging

### DIFF
--- a/app/go.mod
+++ b/app/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 toolchain go1.24.4
 
 require (
+	github.com/Anthony-Bible/Logging v0.0.0-20260525150021-f765f71559a8
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.0
 	github.com/gin-gonic/gin v1.10.1
@@ -83,8 +84,7 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
-	go.uber.org/atomic v1.9.0 // indirect
-	go.uber.org/multierr v1.9.0 // indirect
+	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/arch v0.17.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect

--- a/app/go.sum
+++ b/app/go.sum
@@ -1,5 +1,7 @@
 filippo.io/edwards25519 v1.2.0 h1:crnVqOiS4jqYleHd9vaKZ+HKtHfllngJIiOpNpoJsjo=
 filippo.io/edwards25519 v1.2.0/go.mod h1:xzAOLCNug/yB62zG1bQ8uziwrIqIuxhctzJT18Q77mc=
+github.com/Anthony-Bible/Logging v0.0.0-20260525150021-f765f71559a8 h1:Xx/kfJsW3CHZ9acFH9qBZIV0irHnc6ZmWCd2IEp0x1A=
+github.com/Anthony-Bible/Logging v0.0.0-20260525150021-f765f71559a8/go.mod h1:5vEcp43tzZDmgEENK7IyaPJDANa/ZFk60IohEBOxiTQ=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
@@ -243,12 +245,12 @@ go.opentelemetry.io/otel/sdk/metric v1.36.0 h1:r0ntwwGosWGaa0CrSt8cuNuTcccMXERFw
 go.opentelemetry.io/otel/sdk/metric v1.36.0/go.mod h1:qTNOhFDfKRwX0yXOqJYegL5WRaW376QbB7P4Pb0qva4=
 go.opentelemetry.io/otel/trace v1.37.0 h1:HLdcFNbRQBE2imdSEgm/kwqmQj1Or1l/7bW6mxVK7z4=
 go.opentelemetry.io/otel/trace v1.37.0/go.mod h1:TlgrlQ+PtQO5XFerSPUYG0JSgGyryXewPGyayAWSBS0=
-go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
-go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
-go.uber.org/multierr v1.9.0 h1:7fIwc/ZtS0q++VgcfqFDxSBZVv/Xo49/SYnDFupUwlI=
-go.uber.org/multierr v1.9.0/go.mod h1:X2jQV1h+kxSjClGpnseKVIxpmcjrj7MNnI0bnlfKTVQ=
+go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
+go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.28.0 h1:IZzaP1Fv73/T/pBMLk4VutPl36uNC+OSUh3JLG3FIjo=
+go.uber.org/zap v1.28.0/go.mod h1:rDLpOi171uODNm/mxFcuYWxDsqWSAVkFdX4XojSKg/Q=
 golang.org/x/arch v0.17.0 h1:4O3dfLzd+lQewptAHqjewQZQDyEdejz3VwgeYwkZneU=
 golang.org/x/arch v0.17.0/go.mod h1:bdwinDaKcfZUGpH09BB7ZmOfhalA8lQdzl62l8gGWsk=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/app/internal/shared/logging/log.go
+++ b/app/internal/shared/logging/log.go
@@ -7,27 +7,47 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	extlogging "github.com/Anthony-Bible/Logging"
 )
 
-var Logger = slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+// exitFunc is overridable for tests.
+var exitFunc = os.Exit
+
+var (
+	slogLogger = slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	// extlogging.New installs SIGUSR1/SIGUSR2 handlers itself when
+	// DisableSignalHandling is false, so no extra wiring is needed here.
+	logger = extlogging.New(extlogging.Config{
+		Backend:        extlogging.NewSlogBackend(slogLogger),
+		Level:          extlogging.LevelInfo,
+		ErrorThreshold: 5,
+		ErrorWindow:    time.Minute,
+		DebugDuration:  5 * time.Minute,
+	})
+)
+
+// Logger preserves the previously exported *slog.Logger handle for backwards
+// compatibility with any code that imported it directly.
+var Logger = slogLogger
 
 type Event struct {
-	logger *slog.Logger
-	level  slog.Level
-	attrs  []any
-	fatal  bool
+	level extlogging.Level
+	attrs []slog.Attr
+	fatal bool
 }
 
-func newEvent(level slog.Level, fatal bool) *Event {
-	return &Event{logger: Logger, level: level, fatal: fatal}
+func newEvent(level extlogging.Level, fatal bool) *Event {
+	return &Event{level: level, fatal: fatal}
 }
 
-func Debug() *Event { return newEvent(slog.LevelDebug, false) }
-func Info() *Event  { return newEvent(slog.LevelInfo, false) }
-func Warn() *Event  { return newEvent(slog.LevelWarn, false) }
-func Error() *Event { return newEvent(slog.LevelError, false) }
+func Debug() *Event { return newEvent(extlogging.LevelDebug, false) }
+func Info() *Event  { return newEvent(extlogging.LevelInfo, false) }
+func Warn() *Event  { return newEvent(extlogging.LevelWarn, false) }
+func Error() *Event { return newEvent(extlogging.LevelError, false) }
 func Fatal() *Event {
-	e := newEvent(slog.LevelError, true)
+	e := newEvent(extlogging.LevelError, true)
 	e.attrs = append(e.attrs, slog.Bool("fatal", true))
 	return e
 }
@@ -80,9 +100,21 @@ func (e *Event) Interface(key string, value any) *Event {
 }
 
 func (e *Event) Msg(msg string) {
-	e.logger.Log(context.Background(), e.level, msg, e.attrs...)
+	ctx := context.Background()
+	switch e.level {
+	case extlogging.LevelDebug:
+		logger.Debug(ctx, msg, e.attrs...)
+	case extlogging.LevelInfo:
+		logger.Info(ctx, msg, e.attrs...)
+	case extlogging.LevelWarn:
+		logger.Warn(ctx, msg, e.attrs...)
+	case extlogging.LevelError:
+		logger.Error(ctx, msg, e.attrs...)
+	default:
+		logger.Log(ctx, e.level, msg, e.attrs...)
+	}
 	if e.fatal {
-		os.Exit(1)
+		exitFunc(1)
 	}
 }
 
@@ -91,19 +123,18 @@ func (e *Event) Msgf(format string, args ...any) {
 }
 
 func SetLevel(level string) {
-	var l slog.Level
+	var l extlogging.Level
 	switch strings.ToLower(strings.TrimSpace(level)) {
 	case "debug":
-		l = slog.LevelDebug
+		l = extlogging.LevelDebug
 	case "info", "":
-		l = slog.LevelInfo
+		l = extlogging.LevelInfo
 	case "warn", "warning":
-		l = slog.LevelWarn
+		l = extlogging.LevelWarn
 	case "error":
-		l = slog.LevelError
+		l = extlogging.LevelError
 	default:
-		l = slog.LevelInfo
+		l = extlogging.LevelInfo
 	}
-
-	Logger = slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: l}))
+	logger.SetLevel(l)
 }

--- a/app/internal/shared/logging/log_test.go
+++ b/app/internal/shared/logging/log_test.go
@@ -1,19 +1,58 @@
 package logging
 
 import (
-	"bytes"
+	"context"
 	"errors"
 	"log/slog"
-	"strings"
 	"testing"
+	"time"
+
+	extlogging "github.com/Anthony-Bible/Logging"
 )
 
-func TestEventLogsStructuredFields(t *testing.T) {
-	original := Logger
-	t.Cleanup(func() { Logger = original })
+type recordedEntry struct {
+	level extlogging.Level
+	msg   string
+	attrs []slog.Attr
+}
 
-	var buf bytes.Buffer
-	Logger = slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+type recordingBackend struct {
+	entries []recordedEntry
+}
+
+func (r *recordingBackend) Log(_ context.Context, level extlogging.Level, msg string, attrs ...slog.Attr) {
+	r.entries = append(r.entries, recordedEntry{level: level, msg: msg, attrs: append([]slog.Attr(nil), attrs...)})
+}
+
+// installRecorder swaps the package logger for one backed by a recorder so
+// tests can inspect emitted records. It returns the recorder plus a cleanup.
+func installRecorder(t *testing.T, level extlogging.Level) *recordingBackend {
+	t.Helper()
+	original := logger
+	rec := &recordingBackend{}
+	logger = extlogging.New(extlogging.Config{
+		Backend:               rec,
+		Level:                 level,
+		ErrorThreshold:        5,
+		ErrorWindow:           time.Minute,
+		DebugDuration:         5 * time.Minute,
+		DisableSignalHandling: true,
+	})
+	t.Cleanup(func() { logger = original })
+	return rec
+}
+
+func findAttr(attrs []slog.Attr, key string) (slog.Attr, bool) {
+	for _, a := range attrs {
+		if a.Key == key {
+			return a, true
+		}
+	}
+	return slog.Attr{}, false
+}
+
+func TestEventLogsStructuredFields(t *testing.T) {
+	rec := installRecorder(t, extlogging.LevelDebug)
 
 	Error().
 		Str("component", "unit-test").
@@ -21,47 +60,130 @@ func TestEventLogsStructuredFields(t *testing.T) {
 		Err(errors.New("boom")).
 		Msg("log message")
 
-	output := buf.String()
-	for _, expected := range []string{`"msg":"log message"`, `"component":"unit-test"`, `"attempt":2`, `"error":"boom"`} {
-		if !strings.Contains(output, expected) {
-			t.Fatalf("expected output to contain %s, got: %s", expected, output)
+	if len(rec.entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(rec.entries))
+	}
+	entry := rec.entries[0]
+	if entry.level != extlogging.LevelError {
+		t.Errorf("expected LevelError, got %v", entry.level)
+	}
+	if entry.msg != "log message" {
+		t.Errorf("expected msg 'log message', got %q", entry.msg)
+	}
+	if a, ok := findAttr(entry.attrs, "component"); !ok || a.Value.String() != "unit-test" {
+		t.Errorf("expected component=unit-test, got %+v", a)
+	}
+	if a, ok := findAttr(entry.attrs, "attempt"); !ok || a.Value.Int64() != 2 {
+		t.Errorf("expected attempt=2, got %+v", a)
+	}
+	if _, ok := findAttr(entry.attrs, "error"); !ok {
+		t.Errorf("expected error attribute")
+	}
+}
+
+func TestAllBuilderMethods(t *testing.T) {
+	rec := installRecorder(t, extlogging.LevelDebug)
+
+	Info().
+		Str("s", "v").
+		Int("i", 1).
+		Int32("i32", 32).
+		Int64("i64", 64).
+		Bool("b", true).
+		Dur("d", 2*time.Second).
+		Float64("f", 1.5).
+		Interface("any", map[string]int{"x": 1}).
+		Msg("all fields")
+
+	if len(rec.entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(rec.entries))
+	}
+	for _, key := range []string{"s", "i", "i32", "i64", "b", "d", "f", "any"} {
+		if _, ok := findAttr(rec.entries[0].attrs, key); !ok {
+			t.Errorf("missing attr %q", key)
 		}
 	}
 }
 
-func TestSetLevelAndMsgf(t *testing.T) {
-	original := Logger
-	t.Cleanup(func() { Logger = original })
-
-	var buf bytes.Buffer
-	SetLevel("debug")
-	Logger = slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
-
-	if Logger == nil {
-		t.Fatal("expected logger to be initialized")
-	}
+func TestMsgfAndLevels(t *testing.T) {
+	rec := installRecorder(t, extlogging.LevelDebug)
 
 	Debug().Msgf("message %d", 1)
-	output := buf.String()
-	if !strings.Contains(output, `"level":"DEBUG"`) {
-		t.Errorf("expected level DEBUG, got output: %s", output)
+	Info().Msg("info")
+	Warn().Msg("warn")
+	Error().Msg("err")
+
+	if len(rec.entries) != 4 {
+		t.Fatalf("expected 4 entries, got %d", len(rec.entries))
 	}
-	if !strings.Contains(output, `"msg":"message 1"`) {
-		t.Errorf("expected message 1, got output: %s", output)
+	if rec.entries[0].msg != "message 1" || rec.entries[0].level != extlogging.LevelDebug {
+		t.Errorf("debug entry wrong: %+v", rec.entries[0])
+	}
+	if rec.entries[1].level != extlogging.LevelInfo {
+		t.Errorf("info entry wrong level: %v", rec.entries[1].level)
+	}
+	if rec.entries[2].level != extlogging.LevelWarn {
+		t.Errorf("warn entry wrong level: %v", rec.entries[2].level)
+	}
+	if rec.entries[3].level != extlogging.LevelError {
+		t.Errorf("error entry wrong level: %v", rec.entries[3].level)
 	}
 }
 
-func TestFatalLog(t *testing.T) {
-	// We can't easily test os.Exit(1), so we just test the attribute is added
-	e := Fatal()
-	found := false
-	for _, attr := range e.attrs {
-		if a, ok := attr.(slog.Attr); ok && a.Key == "fatal" && a.Value.Bool() == true {
-			found = true
-			break
+func TestSetLevelFiltersBelowThreshold(t *testing.T) {
+	rec := installRecorder(t, extlogging.LevelDebug)
+
+	SetLevel("warn")
+	t.Cleanup(func() { SetLevel("info") })
+
+	Debug().Msg("debug")
+	Info().Msg("info")
+	Warn().Msg("warn")
+
+	if len(rec.entries) != 1 {
+		t.Fatalf("expected 1 entry after filtering, got %d", len(rec.entries))
+	}
+	if rec.entries[0].level != extlogging.LevelWarn {
+		t.Errorf("expected warn entry, got %v", rec.entries[0].level)
+	}
+}
+
+func TestSetLevelAliases(t *testing.T) {
+	cases := map[string]extlogging.Level{
+		"debug":   extlogging.LevelDebug,
+		"info":    extlogging.LevelInfo,
+		"":        extlogging.LevelInfo,
+		"warn":    extlogging.LevelWarn,
+		"warning": extlogging.LevelWarn,
+		"error":   extlogging.LevelError,
+		"bogus":   extlogging.LevelInfo,
+	}
+	t.Cleanup(func() { SetLevel("info") })
+	for input, want := range cases {
+		SetLevel(input)
+		if got := logger.Level(); got != want {
+			t.Errorf("SetLevel(%q): got %v, want %v", input, got, want)
 		}
 	}
-	if !found {
-		t.Error("expected fatal=true attribute in Fatal() event")
+}
+
+func TestFatalCallsExit(t *testing.T) {
+	rec := installRecorder(t, extlogging.LevelDebug)
+
+	originalExit := exitFunc
+	var exitCode int
+	exitFunc = func(code int) { exitCode = code }
+	t.Cleanup(func() { exitFunc = originalExit })
+
+	Fatal().Str("k", "v").Msg("dying")
+
+	if exitCode != 1 {
+		t.Errorf("expected exit code 1, got %d", exitCode)
+	}
+	if len(rec.entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(rec.entries))
+	}
+	if a, ok := findAttr(rec.entries[0].attrs, "fatal"); !ok || !a.Value.Bool() {
+		t.Errorf("expected fatal=true attribute")
 	}
 }


### PR DESCRIPTION
Reimplement app/internal/shared/logging on top of
github.com/Anthony-Bible/Logging while preserving the existing zerolog-style
fluent surface (.Str().Err().Msg()) so the ~151 call sites across cmd/ and
the four domains require no changes.

Gains runtime SIGUSR1/SIGUSR2 verbosity toggling and an error-burst
auto-debug window (5 errors / 1min -> 5min Debug) from the library defaults.
SetLevel still parses the same level strings.

Tests now exercise the shim through a recording Backend implementation
instead of asserting JSON output, and cover all builder methods, level
filtering, level-string aliases, and Fatal exit dispatch.