### PR TITLE
feat(observability): add P0 k8s health probes (#468)

### DIFF
--- a/app/cmd/email/recieve.go
+++ b/app/cmd/email/recieve.go
@@ -3,6 +3,7 @@ package email
 import (
 	"context"
 
+	healthhttp "github.com/Anthony-Bible/password-exchange/app/internal/domains/notification/adapters/primary/http"
 	notificationConsumer "github.com/Anthony-Bible/password-exchange/app/internal/domains/notification/adapters/primary/consumer"
 	"github.com/Anthony-Bible/password-exchange/app/internal/domains/notification/adapters/secondary/logger"
 	rabbitMQConsumer "github.com/Anthony-Bible/password-exchange/app/internal/domains/notification/adapters/secondary/rabbitmq"
@@ -35,7 +36,8 @@ func (conf Config) StartProcessing() {
 }
 
 func (conf Config) startHexagonalProcessing() {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	// Create email connection configuration
 	emailConn := notificationDomain.EmailConnection{
@@ -69,6 +71,16 @@ func (conf Config) startHexagonalProcessing() {
 
 	// Create primary adapter (consumer)
 	consumer := notificationConsumer.NewNotificationConsumer(notificationService, queueConn, 100)
+
+	// Start health endpoint alongside the consumer so Kubernetes can liveness-probe
+	// the email worker (the consumer goroutine doesn't otherwise surface a wedged
+	// AMQP connection).
+	healthAdapter := healthhttp.NewHealthServer(":8080", queueConsumer)
+	go func() {
+		if err := healthAdapter.Start(ctx); err != nil {
+			logging.Error().Err(err).Msg("Health endpoint exited with error")
+		}
+	}()
 
 	// Start processing
 	logging.Info().Msg("Starting notification service with hexagonal architecture")

--- a/app/internal/domains/encryption/adapters/primary/grpc/health_test.go
+++ b/app/internal/domains/encryption/adapters/primary/grpc/health_test.go
@@ -1,0 +1,57 @@
+package grpc
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	pb "github.com/Anthony-Bible/password-exchange/app/pkg/pb/encryption"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+func startHealthTestServer(t *testing.T) (grpc_health_v1.HealthClient, func()) {
+	t.Helper()
+	lis := bufconn.Listen(1024 * 1024)
+	srv := grpc.NewServer()
+	adapter := NewGRPCServer(&stubService{}, "", stubLogger{})
+	pb.RegisterMessageServiceServer(srv, adapter)
+	adapter.registerHealthServer(srv)
+
+	serveErrCh := make(chan error, 1)
+	go func() {
+		serveErrCh <- srv.Serve(lis)
+	}()
+
+	conn, err := grpc.NewClient(
+		"passthrough://bufnet",
+		grpc.WithContextDialer(func(_ context.Context, _ string) (net.Conn, error) { return lis.Dial() }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+
+	cleanup := func() {
+		_ = conn.Close()
+		srv.Stop()
+		_ = lis.Close()
+		if serveErr := <-serveErrCh; serveErr != nil && !errors.Is(serveErr, grpc.ErrServerStopped) {
+			t.Errorf("gRPC Serve returned unexpected error: %v", serveErr)
+		}
+	}
+	return grpc_health_v1.NewHealthClient(conn), cleanup
+}
+
+func TestHealthCheck_Serving(t *testing.T) {
+	client, cleanup := startHealthTestServer(t)
+	t.Cleanup(cleanup)
+
+	resp, err := client.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{Service: ""})
+
+	require.NoError(t, err)
+	assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.GetStatus())
+}

--- a/app/internal/domains/encryption/adapters/primary/grpc/server.go
+++ b/app/internal/domains/encryption/adapters/primary/grpc/server.go
@@ -9,6 +9,8 @@ import (
 	"github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/ports/secondary"
 	pb "github.com/Anthony-Bible/password-exchange/app/pkg/pb/encryption"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
 )
 
@@ -39,6 +41,7 @@ func (s *GRPCServer) Start() error {
 
 	grpcServer := grpc.NewServer()
 	pb.RegisterMessageServiceServer(grpcServer, s)
+	s.registerHealthServer(grpcServer)
 	reflection.Register(grpcServer)
 
 	s.logger.Info().Str("address", s.address).Msg("Starting encryption gRPC server")
@@ -48,6 +51,14 @@ func (s *GRPCServer) Start() error {
 	}
 
 	return nil
+}
+
+// registerHealthServer wires the standard gRPC health service so Kubernetes
+// grpc probes can verify the encryption server is serving.
+func (s *GRPCServer) registerHealthServer(grpcServer *grpc.Server) {
+	healthSrv := health.NewServer()
+	healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+	grpc_health_v1.RegisterHealthServer(grpcServer, healthSrv)
 }
 
 // EncryptMessage handles encryption requests

--- a/app/internal/domains/notification/adapters/primary/http/health.go
+++ b/app/internal/domains/notification/adapters/primary/http/health.go
@@ -1,0 +1,90 @@
+// Package http exposes a minimal HTTP primary adapter for the notification
+// (email) worker. Its sole responsibility is serving a /healthz probe so
+// Kubernetes can restart the pod when the underlying queue connection has
+// dropped — a failure mode the consumer goroutine doesn't otherwise surface.
+package http
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+)
+
+// QueueHealth is the minimal contract the health endpoint needs from the
+// upstream queue adapter. It is declared locally so this primary adapter does
+// not import the RabbitMQ secondary adapter, preserving the hexagonal
+// dependency direction (adapters depend on the domain, never on each other).
+type QueueHealth interface {
+	IsConnectionAlive() bool
+}
+
+// HealthServer serves a /healthz endpoint that reports queue connection
+// liveness. It is intentionally tiny: no metrics, no auth, no readiness — just
+// enough surface for a Kubernetes liveness probe on the email worker.
+type HealthServer struct {
+	addr  string
+	queue QueueHealth
+	srv   *http.Server
+}
+
+// NewHealthServer constructs a HealthServer bound to addr (e.g. ":8080") that
+// reports the given queue's connection status via GET /healthz.
+func NewHealthServer(addr string, queue QueueHealth) *HealthServer {
+	return &HealthServer{
+		addr:  addr,
+		queue: queue,
+	}
+}
+
+// Handler returns the HTTP handler used by Start. It is exported so callers
+// (and tests) can drive the routes directly via httptest without binding a
+// listener.
+func (h *HealthServer) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /healthz", h.healthz)
+	return mux
+}
+
+// healthz writes 200 "ok" when the queue connection is alive, otherwise 503
+// with a short diagnostic body.
+func (h *HealthServer) healthz(w http.ResponseWriter, _ *http.Request) {
+	if !h.queue.IsConnectionAlive() {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("queue connection closed"))
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
+}
+
+// Start runs the HTTP server and blocks until ctx is cancelled, at which point
+// it triggers a graceful shutdown with a short timeout. Returns nil for the
+// normal shutdown path, otherwise the underlying ListenAndServe error.
+func (h *HealthServer) Start(ctx context.Context) error {
+	h.srv = &http.Server{
+		Addr:              h.addr,
+		Handler:           h.Handler(),
+		ReadHeaderTimeout: 5 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		if err := h.srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+			return
+		}
+		errCh <- nil
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = h.srv.Shutdown(shutdownCtx)
+		return nil
+	case err := <-errCh:
+		return err
+	}
+}

--- a/app/internal/domains/notification/adapters/primary/http/health_test.go
+++ b/app/internal/domains/notification/adapters/primary/http/health_test.go
@@ -1,0 +1,72 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// stubQueue is a fixed-state QueueHealth used by the table tests.
+type stubQueue struct{ alive bool }
+
+func (s stubQueue) IsConnectionAlive() bool { return s.alive }
+
+func TestHealthzHandler(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		alive      bool
+		wantStatus int
+		wantBody   string
+	}{
+		{
+			name:       "queue connection alive returns 200 ok",
+			alive:      true,
+			wantStatus: http.StatusOK,
+			wantBody:   "ok",
+		},
+		{
+			name:       "queue connection dead returns 503",
+			alive:      false,
+			wantStatus: http.StatusServiceUnavailable,
+			wantBody:   "queue connection closed",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := NewHealthServer(":0", stubQueue{alive: tc.alive})
+			req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+			rec := httptest.NewRecorder()
+
+			srv.Handler().ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Errorf("status: got %d, want %d", rec.Code, tc.wantStatus)
+			}
+			if got := rec.Body.String(); got != tc.wantBody {
+				t.Errorf("body: got %q, want %q", got, tc.wantBody)
+			}
+		})
+	}
+}
+
+func TestHealthzRejectsNonGET(t *testing.T) {
+	t.Parallel()
+
+	srv := NewHealthServer(":0", stubQueue{alive: true})
+
+	// The Go 1.22 mux pattern "GET /healthz" will return 405 for other methods
+	// when the path matches but the method does not.
+	req := httptest.NewRequest(http.MethodPost, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status: got %d, want %d", rec.Code, http.StatusMethodNotAllowed)
+	}
+}

--- a/app/internal/domains/notification/adapters/secondary/rabbitmq/consumer.go
+++ b/app/internal/domains/notification/adapters/secondary/rabbitmq/consumer.go
@@ -187,3 +187,28 @@ func (r *RabbitMQConsumer) Close() error {
 	logging.Info().Msg("RabbitMQ connection closed")
 	return nil
 }
+
+// connStatus is the minimal surface of *amqp.Connection needed for liveness
+// checks. Extracted so tests can exercise the closed/open branches without
+// requiring a real broker.
+type connStatus interface {
+	IsClosed() bool
+}
+
+// isConnAlive returns true when the connection is non-nil and reports itself
+// as not closed. Split from IsConnectionAlive so the not-nil branch is
+// testable via a fake connStatus.
+func isConnAlive(c connStatus) bool {
+	return c != nil && !c.IsClosed()
+}
+
+// IsConnectionAlive reports whether the underlying AMQP connection is non-nil
+// and has not been closed. Used by the email worker's /healthz endpoint so a
+// wedged consumer (e.g. channel closed, connection dropped) gets restarted by
+// Kubernetes instead of silently accepting deliveries it can't process.
+func (r *RabbitMQConsumer) IsConnectionAlive() bool {
+	if r.connection == nil {
+		return false
+	}
+	return isConnAlive(r.connection)
+}

--- a/app/internal/domains/notification/adapters/secondary/rabbitmq/consumer_test.go
+++ b/app/internal/domains/notification/adapters/secondary/rabbitmq/consumer_test.go
@@ -319,6 +319,47 @@ func TestProtobufMarshalUnmarshal_RoundTrip(t *testing.T) {
 	assert.Equal(t, originalMsg.Captcha, unmarshaledMsg.Captcha)
 }
 
+// stubConn is a test double for the connStatus seam so we can exercise both
+// the "closed" and "alive" branches of isConnAlive without dialing a real
+// AMQP broker (unit tests must not require RabbitMQ).
+type stubConn struct {
+	closed bool
+}
+
+func (s stubConn) IsClosed() bool { return s.closed }
+
+func TestIsConnectionAlive(t *testing.T) {
+	t.Run("nil connection returns false", func(t *testing.T) {
+		// The public method must short-circuit on a nil *amqp.Connection so
+		// /healthz reports unhealthy before Connect has been called.
+		consumer := &RabbitMQConsumer{connection: nil}
+		assert.False(t, consumer.IsConnectionAlive())
+	})
+
+	testCases := []struct {
+		name string
+		conn connStatus
+		want bool
+	}{
+		{
+			name: "closed connection returns false",
+			conn: stubConn{closed: true},
+			want: false,
+		},
+		{
+			name: "open connection returns true",
+			conn: stubConn{closed: false},
+			want: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isConnAlive(tc.conn))
+		})
+	}
+}
+
 func TestProtobufMessage_FieldValidation(t *testing.T) {
 	// Test protobuf message field validation and edge cases
 	testCases := []struct {

--- a/app/internal/domains/storage/adapters/primary/grpc/health_test.go
+++ b/app/internal/domains/storage/adapters/primary/grpc/health_test.go
@@ -1,0 +1,59 @@
+package grpc
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	database "github.com/Anthony-Bible/password-exchange/app/pkg/pb/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// TestRegisterHealthServer_OverallServiceReportsServing verifies that after the
+// storage adapter registers the standard gRPC health service, a Check call for
+// the overall service ("") returns SERVING. k8s grpc: probes rely on this exact
+// contract to mark pods Ready.
+func TestRegisterHealthServer_OverallServiceReportsServing(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubStorageService{}
+	logger := &recordingLogger{}
+	validator := &stubValidator{}
+	adapter := NewGRPCServer(svc, "", logger, validator)
+
+	lis := bufconn.Listen(1024 * 1024)
+	grpcServer := grpc.NewServer()
+	database.RegisterDbServiceServer(grpcServer, adapter)
+	adapter.registerHealthServer(grpcServer)
+
+	serveErrCh := make(chan error, 1)
+	go func() {
+		serveErrCh <- grpcServer.Serve(lis)
+	}()
+	t.Cleanup(func() {
+		grpcServer.Stop()
+		_ = lis.Close()
+		if err := <-serveErrCh; err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+			t.Errorf("gRPC Serve returned unexpected error: %v", err)
+		}
+	})
+
+	conn, err := grpc.NewClient(
+		"passthrough://bufnet",
+		grpc.WithContextDialer(func(_ context.Context, _ string) (net.Conn, error) { return lis.Dial() }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	client := grpc_health_v1.NewHealthClient(conn)
+	resp, err := client.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{Service: ""})
+	require.NoError(t, err)
+	assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.GetStatus())
+}

--- a/app/internal/domains/storage/adapters/primary/grpc/server.go
+++ b/app/internal/domains/storage/adapters/primary/grpc/server.go
@@ -14,6 +14,8 @@ import (
 	database "github.com/Anthony-Bible/password-exchange/app/pkg/pb/database"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -294,6 +296,16 @@ func (s *GRPCServer) runExpiredMessageCleanup(ctx context.Context) {
 	}
 }
 
+// registerHealthServer wires the standard gRPC health service into the given
+// server with the overall service ("") marked SERVING. k8s grpc: probes need a
+// SERVING response on this contract to mark the pod Ready; deeper per-component
+// health (e.g. DB connectivity) is intentionally out of scope here.
+func (s *GRPCServer) registerHealthServer(grpcServer *grpc.Server) {
+	healthSrv := health.NewServer()
+	healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+	grpc_health_v1.RegisterHealthServer(grpcServer, healthSrv)
+}
+
 // Start starts the gRPC server. Fatal lifecycle decisions (process exit) are
 // left to the caller so the adapter remains a pure transport layer.
 func (s *GRPCServer) Start() error {
@@ -305,6 +317,7 @@ func (s *GRPCServer) Start() error {
 
 	grpcServer := grpc.NewServer()
 	database.RegisterDbServiceServer(grpcServer, s)
+	s.registerHealthServer(grpcServer)
 	reflection.Register(grpcServer)
 
 	// Run expired message cleanup in the background; cancel it when Start returns.

--- a/k8s/database.deployment.yaml
+++ b/k8s/database.deployment.yaml
@@ -45,5 +45,23 @@ spec:
         - name: "PASSWORDEXCHANGE_RUNNING_ENVIRONMENT"
           value: "%{PHASE}"
         name: database
+        ports:
+        - containerPort: 50051
+          name: grpc
+          protocol: TCP
+        livenessProbe:
+          grpc:
+            port: 50051
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          grpc:
+            port: 50051
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
 
 

--- a/k8s/email.deployment.yaml
+++ b/k8s/email.deployment.yaml
@@ -42,8 +42,14 @@ spec:
         name: email
         ports:
         - containerPort: 8080
-
-
-
-
+          name: http
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 3
 

--- a/k8s/encryption.deployment.yaml
+++ b/k8s/encryption.deployment.yaml
@@ -31,6 +31,24 @@ spec:
         - name: "PASSWORDEXCHANGE_RUNNING_ENVIRONMENT"
           value: "%{PHASE}"
         name: encryption
+        ports:
+        - containerPort: 50051
+          name: grpc
+          protocol: TCP
+        livenessProbe:
+          grpc:
+            port: 50051
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          grpc:
+            port: 50051
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
 
 ---
 


### PR DESCRIPTION
Register standard gRPC health service on database and encryption servers, add an HTTP /healthz endpoint on the email worker backed by AMQP connection state, and wire matching probes into the deployments.

Without these, a wedged email consumer or frozen gRPC server keeps receiving traffic until downstream timeouts cascade.