### PR TITLE
feat(observability): add P1 k8s health probes

### DIFF
--- a/app/cmd/email/recieve.go
+++ b/app/cmd/email/recieve.go
@@ -77,8 +77,12 @@ func (conf Config) startHexagonalProcessing() {
 	// AMQP connection).
 	healthAdapter := healthhttp.NewHealthServer(":8080", queueConsumer)
 	go func() {
+		// Start returns nil on the normal ctx-cancel shutdown path, so a non-nil
+		// error here means the endpoint never came up (e.g. :8080 bind failure).
+		// Kubernetes liveness/readiness depend on this endpoint, so fail fast and
+		// let the pod restart rather than running in a partially-observable state.
 		if err := healthAdapter.Start(ctx); err != nil {
-			logging.Error().Err(err).Msg("Health endpoint exited with error")
+			logging.Fatal().Err(err).Msg("Health endpoint failed to start; exiting so Kubernetes restarts the pod")
 		}
 	}()
 

--- a/app/cmd/web/forms.go
+++ b/app/cmd/web/forms.go
@@ -90,8 +90,10 @@ func (conf Config) startHexagonalServer() {
 		messageValidation,
 	)
 
-	// Create web server (primary adapter)
-	webServer := webAdapter.NewWebServer(messageService)
+	// Create web server (primary adapter). The encryption + storage clients
+	// are also handed in directly so the /readyz probe can call HealthCheck
+	// on them without re-routing through the message service.
+	webServer := webAdapter.NewWebServer(messageService, encryptionClient, storageClient)
 
 	// Start the server
 	logging.Info().Msg("Starting message service with hexagonal architecture")

--- a/app/internal/domains/encryption/adapters/primary/grpc/server.go
+++ b/app/internal/domains/encryption/adapters/primary/grpc/server.go
@@ -54,7 +54,10 @@ func (s *GRPCServer) Start() error {
 }
 
 // registerHealthServer wires the standard gRPC health service so Kubernetes
-// grpc probes can verify the encryption server is serving.
+// grpc probes can verify the encryption server is serving. Status stays
+// hardcoded SERVING because encryption is purely in-process (key generation
+// has no external dependencies) — if this process is alive enough to answer
+// the health RPC, it can serve real requests too.
 func (s *GRPCServer) registerHealthServer(grpcServer *grpc.Server) {
 	healthSrv := health.NewServer()
 	healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)

--- a/app/internal/domains/message/adapters/primary/api/email_flow_test.go
+++ b/app/internal/domains/message/adapters/primary/api/email_flow_test.go
@@ -209,7 +209,7 @@ func TestEmailNotificationFlow(t *testing.T) {
 			}
 
 			// Create handler
-			handler := NewMessageAPIHandler(mockService)
+			handler := NewMessageAPIHandler(mockService, &stubEncryptionPort{}, &stubStoragePort{})
 
 			// Create request
 			reqBody, err := json.Marshal(tt.request)
@@ -339,7 +339,7 @@ func TestEmailValidationFlow(t *testing.T) {
 			}
 
 			// Create handler
-			handler := NewMessageAPIHandler(mockService)
+			handler := NewMessageAPIHandler(mockService, &stubEncryptionPort{}, &stubStoragePort{})
 
 			// Create request
 			reqBody, err := json.Marshal(request)
@@ -495,7 +495,7 @@ func TestConditionalValidationFlow(t *testing.T) {
 			}
 
 			// Create handler
-			handler := NewMessageAPIHandler(mockService)
+			handler := NewMessageAPIHandler(mockService, &stubEncryptionPort{}, &stubStoragePort{})
 
 			// Create request
 			reqBody, err := json.Marshal(request)

--- a/app/internal/domains/message/adapters/primary/api/handlers.go
+++ b/app/internal/domains/message/adapters/primary/api/handlers.go
@@ -4,25 +4,42 @@ import (
 	"context"
 	"encoding/base64"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/Anthony-Bible/password-exchange/app/internal/domains/message/adapters/primary/api/middleware"
 	"github.com/Anthony-Bible/password-exchange/app/internal/domains/message/adapters/primary/api/models"
 	"github.com/Anthony-Bible/password-exchange/app/internal/domains/message/domain"
 	"github.com/Anthony-Bible/password-exchange/app/internal/domains/message/ports/primary"
+	"github.com/Anthony-Bible/password-exchange/app/internal/domains/message/ports/secondary"
 	"github.com/Anthony-Bible/password-exchange/app/internal/shared/logging"
 	"github.com/gin-gonic/gin"
 )
 
+// readyzTimeout bounds how long Readyz waits on its downstream HealthCheck
+// calls before failing. Must stay tight so k8s readiness probes don't queue
+// up behind a wedged dependency.
+const readyzTimeout = 2 * time.Second
+
 // MessageAPIHandler handles REST API requests for message operations
 type MessageAPIHandler struct {
-	messageService primary.MessageServicePort
+	messageService    primary.MessageServicePort
+	encryptionService secondary.EncryptionServicePort
+	storageService    secondary.StorageServicePort
 }
 
-// NewMessageAPIHandler creates a new API message handler
-func NewMessageAPIHandler(messageService primary.MessageServicePort) *MessageAPIHandler {
+// NewMessageAPIHandler creates a new API message handler. The two secondary
+// ports are required for the dependency-aware /readyz probe; SubmitMessage
+// and friends route through messageService as before.
+func NewMessageAPIHandler(
+	messageService primary.MessageServicePort,
+	encryptionService secondary.EncryptionServicePort,
+	storageService secondary.StorageServicePort,
+) *MessageAPIHandler {
 	return &MessageAPIHandler{
-		messageService: messageService,
+		messageService:    messageService,
+		encryptionService: encryptionService,
+		storageService:    storageService,
 	}
 }
 
@@ -336,6 +353,59 @@ func (h *MessageAPIHandler) HealthCheck(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, response)
+}
+
+// Livez handles GET /livez. It returns 200 unconditionally without touching
+// any downstream dependency so kubelet only restarts the process when it is
+// genuinely wedged (not when a database hiccup degrades readiness).
+func (h *MessageAPIHandler) Livez(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+// Readyz handles GET /readyz. It probes both downstream gRPC services in
+// parallel under a short deadline; if either fails the pod is taken off the
+// service load balancer with a 503 and a small JSON body naming the failed
+// dep(s). On success it returns 200 with {"status":"ok"}.
+func (h *MessageAPIHandler) Readyz(c *gin.Context) {
+	ctx, cancel := context.WithTimeout(c.Request.Context(), readyzTimeout)
+	defer cancel()
+
+	var (
+		wg     sync.WaitGroup
+		mu     sync.Mutex
+		failed []string
+	)
+
+	checks := []struct {
+		name string
+		fn   func(context.Context) error
+	}{
+		{"encryption", h.encryptionService.HealthCheck},
+		{"storage", h.storageService.HealthCheck},
+	}
+
+	for _, check := range checks {
+		wg.Add(1)
+		go func(name string, fn func(context.Context) error) {
+			defer wg.Done()
+			if err := fn(ctx); err != nil {
+				mu.Lock()
+				failed = append(failed, name)
+				mu.Unlock()
+				logging.Warn().Err(err).Str("dep", name).Msg("Readyz dependency check failed")
+			}
+		}(check.name, check.fn)
+	}
+	wg.Wait()
+
+	if len(failed) > 0 {
+		c.JSON(http.StatusServiceUnavailable, gin.H{
+			"status": "unavailable",
+			"failed": failed,
+		})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
 }
 
 // APIInfo handles GET /api/v1/info

--- a/app/internal/domains/message/adapters/primary/api/handlers_test.go
+++ b/app/internal/domains/message/adapters/primary/api/handlers_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -12,10 +13,12 @@ import (
 	"github.com/Anthony-Bible/password-exchange/app/internal/domains/message/adapters/primary/api/middleware"
 	"github.com/Anthony-Bible/password-exchange/app/internal/domains/message/adapters/primary/api/models"
 	"github.com/Anthony-Bible/password-exchange/app/internal/domains/message/domain"
+	"github.com/Anthony-Bible/password-exchange/app/internal/domains/message/ports/contracts"
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // MockMessageService is a mock implementation of MessageServicePort
@@ -47,14 +50,81 @@ func (m *MockMessageService) RetrieveMessage(
 	return args.Get(0).(*domain.MessageRetrievalResponse), args.Error(1)
 }
 
+// healthCheckFn is a tiny test-only function-typed implementation of the
+// HealthCheck contract for both secondary ports. Tests inject a closure that
+// returns the desired error/timing behaviour without standing up a full mock.
+type healthCheckFn func(ctx context.Context) error
+
+// stubEncryptionPort satisfies secondary.EncryptionServicePort. Only
+// HealthCheck is exercised by Readyz tests; the other methods panic if
+// called so misuse fails loudly.
+type stubEncryptionPort struct {
+	healthCheck healthCheckFn
+}
+
+func (s *stubEncryptionPort) GenerateKey(context.Context, int32) ([]byte, error) {
+	panic("stubEncryptionPort.GenerateKey not implemented")
+}
+func (s *stubEncryptionPort) Encrypt(context.Context, []string, []byte) ([]string, error) {
+	panic("stubEncryptionPort.Encrypt not implemented")
+}
+func (s *stubEncryptionPort) Decrypt(context.Context, []string, []byte) ([]string, error) {
+	panic("stubEncryptionPort.Decrypt not implemented")
+}
+func (s *stubEncryptionPort) GenerateID(context.Context) (string, error) {
+	panic("stubEncryptionPort.GenerateID not implemented")
+}
+func (s *stubEncryptionPort) HealthCheck(ctx context.Context) error {
+	if s.healthCheck == nil {
+		return nil
+	}
+	return s.healthCheck(ctx)
+}
+
+// stubStoragePort satisfies secondary.StorageServicePort with the same
+// "only HealthCheck is real" pattern.
+type stubStoragePort struct {
+	healthCheck healthCheckFn
+}
+
+func (s *stubStoragePort) StoreMessage(context.Context, contracts.MessageStorageRequest) error {
+	panic("stubStoragePort.StoreMessage not implemented")
+}
+func (s *stubStoragePort) RetrieveMessage(
+	context.Context,
+	contracts.MessageRetrievalStorageRequest,
+) (*contracts.MessageStorageResponse, error) {
+	panic("stubStoragePort.RetrieveMessage not implemented")
+}
+func (s *stubStoragePort) GetMessage(
+	context.Context,
+	contracts.MessageRetrievalStorageRequest,
+) (*contracts.MessageStorageResponse, error) {
+	panic("stubStoragePort.GetMessage not implemented")
+}
+func (s *stubStoragePort) HealthCheck(ctx context.Context) error {
+	if s.healthCheck == nil {
+		return nil
+	}
+	return s.healthCheck(ctx)
+}
+
 func setupTestRouter(mockService *MockMessageService) *gin.Engine {
+	return setupTestRouterWithProbes(mockService, &stubEncryptionPort{}, &stubStoragePort{})
+}
+
+func setupTestRouterWithProbes(
+	mockService *MockMessageService,
+	enc *stubEncryptionPort,
+	stor *stubStoragePort,
+) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 
 	// Create minimal metrics setup for testing
 	registry := prometheus.NewRegistry()
 	metrics := middleware.NewPrometheusMetrics(registry)
 
-	return setupRouter(NewMessageAPIHandler(mockService), metrics, registry)
+	return setupRouter(NewMessageAPIHandler(mockService, enc, stor), metrics, registry)
 }
 
 func TestSubmitMessage_Success(t *testing.T) {
@@ -595,6 +665,138 @@ func TestDecryptMessage_IncludesExpiresAt(t *testing.T) {
 	assert.Equal(t, fixedExpiry.Unix(), response.ExpiresAt.Unix())
 
 	mockService.AssertExpectations(t)
+}
+
+func TestLivez_AlwaysReturns200WithoutTouchingDependencies(t *testing.T) {
+	mockService := new(MockMessageService)
+	// Deps panic if their HealthCheck is called — proves /livez is dependency-free.
+	enc := &stubEncryptionPort{healthCheck: func(context.Context) error {
+		t.Fatalf("/livez must not call encryption HealthCheck")
+		return nil
+	}}
+	stor := &stubStoragePort{healthCheck: func(context.Context) error {
+		t.Fatalf("/livez must not call storage HealthCheck")
+		return nil
+	}}
+	router := setupTestRouterWithProbes(mockService, enc, stor)
+
+	req, _ := http.NewRequest("GET", "/livez", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var body map[string]string
+	require := require.New(t)
+	require.NoError(json.Unmarshal(w.Body.Bytes(), &body))
+	require.Equal("ok", body["status"])
+}
+
+func TestReadyz_ReturnsOKWhenBothDependenciesHealthy(t *testing.T) {
+	mockService := new(MockMessageService)
+	enc := &stubEncryptionPort{healthCheck: func(context.Context) error { return nil }}
+	stor := &stubStoragePort{healthCheck: func(context.Context) error { return nil }}
+	router := setupTestRouterWithProbes(mockService, enc, stor)
+
+	req, _ := http.NewRequest("GET", "/readyz", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestReadyz_Returns503WhenEncryptionUnhealthy(t *testing.T) {
+	mockService := new(MockMessageService)
+	enc := &stubEncryptionPort{healthCheck: func(context.Context) error {
+		return errors.New("encryption down")
+	}}
+	stor := &stubStoragePort{healthCheck: func(context.Context) error { return nil }}
+	router := setupTestRouterWithProbes(mockService, enc, stor)
+
+	req, _ := http.NewRequest("GET", "/readyz", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	var body map[string]interface{}
+	require := require.New(t)
+	require.NoError(json.Unmarshal(w.Body.Bytes(), &body))
+	require.Contains(body, "failed")
+	failed, _ := body["failed"].([]interface{})
+	require.Contains(failed, "encryption")
+}
+
+func TestReadyz_Returns503WhenStorageUnhealthy(t *testing.T) {
+	mockService := new(MockMessageService)
+	enc := &stubEncryptionPort{healthCheck: func(context.Context) error { return nil }}
+	stor := &stubStoragePort{healthCheck: func(context.Context) error {
+		return errors.New("storage down")
+	}}
+	router := setupTestRouterWithProbes(mockService, enc, stor)
+
+	req, _ := http.NewRequest("GET", "/readyz", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	var body map[string]interface{}
+	require := require.New(t)
+	require.NoError(json.Unmarshal(w.Body.Bytes(), &body))
+	failed, _ := body["failed"].([]interface{})
+	require.Contains(failed, "storage")
+}
+
+func TestReadyz_Returns503WhenBothUnhealthy(t *testing.T) {
+	mockService := new(MockMessageService)
+	enc := &stubEncryptionPort{healthCheck: func(context.Context) error {
+		return errors.New("encryption down")
+	}}
+	stor := &stubStoragePort{healthCheck: func(context.Context) error {
+		return errors.New("storage down")
+	}}
+	router := setupTestRouterWithProbes(mockService, enc, stor)
+
+	req, _ := http.NewRequest("GET", "/readyz", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	var body map[string]interface{}
+	require := require.New(t)
+	require.NoError(json.Unmarshal(w.Body.Bytes(), &body))
+	failed, _ := body["failed"].([]interface{})
+	require.Contains(failed, "encryption")
+	require.Contains(failed, "storage")
+}
+
+func TestReadyz_AbortsViaContextTimeout(t *testing.T) {
+	// A stuck dependency must not hang readiness. The handler attaches a 2s
+	// deadline to the dispatched context; the stub blocks until that fires
+	// and then returns ctx.Err(), so /readyz must respond 503 rather than
+	// blocking indefinitely.
+	mockService := new(MockMessageService)
+	enc := &stubEncryptionPort{healthCheck: func(ctx context.Context) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}}
+	stor := &stubStoragePort{healthCheck: func(context.Context) error { return nil }}
+	router := setupTestRouterWithProbes(mockService, enc, stor)
+
+	req, _ := http.NewRequest("GET", "/readyz", nil)
+	w := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		router.ServeHTTP(w, req)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("/readyz blocked past the in-handler deadline")
+	}
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
 }
 
 func TestDecryptMessage_NilExpiresAtIsNullInResponse(t *testing.T) {

--- a/app/internal/domains/message/adapters/primary/api/server.go
+++ b/app/internal/domains/message/adapters/primary/api/server.go
@@ -6,6 +6,7 @@ import (
 	_ "github.com/Anthony-Bible/password-exchange/app/docs" // Import generated docs
 	"github.com/Anthony-Bible/password-exchange/app/internal/domains/message/adapters/primary/api/middleware"
 	"github.com/Anthony-Bible/password-exchange/app/internal/domains/message/ports/primary"
+	"github.com/Anthony-Bible/password-exchange/app/internal/domains/message/ports/secondary"
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
 	swaggerFiles "github.com/swaggo/files"
@@ -20,9 +21,15 @@ type Server struct {
 	prometheusMetrics *middleware.PrometheusMetrics
 }
 
-// NewServer creates a new API server with the given message service
-func NewServer(messageService primary.MessageServicePort) *Server {
-	handler := NewMessageAPIHandler(messageService)
+// NewServer creates a new API server with the given message service plus the
+// encryption and storage ports the /readyz probe needs to check downstream
+// dependency health.
+func NewServer(
+	messageService primary.MessageServicePort,
+	encryptionService secondary.EncryptionServicePort,
+	storageService secondary.StorageServicePort,
+) *Server {
+	handler := NewMessageAPIHandler(messageService, encryptionService, storageService)
 
 	// Initialize Prometheus metrics
 	metricsRegistry := prometheus.NewRegistry()
@@ -76,6 +83,13 @@ func setupRouter(
 
 		c.Next()
 	})
+
+	// Process-alive (/livez) and dependency-aware (/readyz) probes live on the
+	// root, not under /api/v1, so k8s probes don't get versioned along with
+	// the public REST surface. Same lenient rate limit as /health to avoid
+	// throttling the kubelet.
+	router.GET("/livez", middleware.HealthCheckRateLimit(), handler.Livez)
+	router.GET("/readyz", middleware.HealthCheckRateLimit(), handler.Readyz)
 
 	// API routes with rate limiting
 	v1 := router.Group("/api/v1")

--- a/app/internal/domains/message/adapters/primary/api/server_rate_limit_test.go
+++ b/app/internal/domains/message/adapters/primary/api/server_rate_limit_test.go
@@ -19,7 +19,7 @@ func TestServerRateLimiting(t *testing.T) {
 
 	t.Run("message submission rate limiting", func(t *testing.T) {
 		mockService := &MockMessageService{}
-		server := NewServer(mockService)
+		server := NewServer(mockService, &stubEncryptionPort{}, &stubStoragePort{})
 		router := server.GetRouter()
 
 		// Mock successful message submission
@@ -78,7 +78,7 @@ func TestServerRateLimiting(t *testing.T) {
 
 	t.Run("message access rate limiting", func(t *testing.T) {
 		mockService := &MockMessageService{}
-		server := NewServer(mockService)
+		server := NewServer(mockService, &stubEncryptionPort{}, &stubStoragePort{})
 		router := server.GetRouter()
 
 		// Mock successful message access
@@ -116,7 +116,7 @@ func TestServerRateLimiting(t *testing.T) {
 
 	t.Run("message decrypt rate limiting", func(t *testing.T) {
 		mockService := &MockMessageService{}
-		server := NewServer(mockService)
+		server := NewServer(mockService, &stubEncryptionPort{}, &stubStoragePort{})
 		router := server.GetRouter()
 
 		// Mock successful message decryption
@@ -164,7 +164,7 @@ func TestServerRateLimiting(t *testing.T) {
 
 	t.Run("health check rate limiting", func(t *testing.T) {
 		mockService := &MockMessageService{}
-		server := NewServer(mockService)
+		server := NewServer(mockService, &stubEncryptionPort{}, &stubStoragePort{})
 		router := server.GetRouter()
 
 		// Test that 300 requests succeed (within rate limit)
@@ -188,7 +188,7 @@ func TestServerRateLimiting(t *testing.T) {
 
 	t.Run("different IPs have separate rate limits", func(t *testing.T) {
 		mockService := &MockMessageService{}
-		server := NewServer(mockService)
+		server := NewServer(mockService, &stubEncryptionPort{}, &stubStoragePort{})
 		router := server.GetRouter()
 
 		// Mock message submission responses
@@ -243,7 +243,7 @@ func TestServerRateLimiting(t *testing.T) {
 
 	t.Run("rate limit error response format", func(t *testing.T) {
 		mockService := &MockMessageService{}
-		server := NewServer(mockService)
+		server := NewServer(mockService, &stubEncryptionPort{}, &stubStoragePort{})
 		router := server.GetRouter()
 
 		// Mock message submission to reach rate limit

--- a/app/internal/domains/message/adapters/primary/web/server.go
+++ b/app/internal/domains/message/adapters/primary/web/server.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Anthony-Bible/password-exchange/app/internal/domains/message/adapters/primary/api"
 	"github.com/Anthony-Bible/password-exchange/app/internal/domains/message/adapters/primary/api/middleware"
 	"github.com/Anthony-Bible/password-exchange/app/internal/domains/message/ports/primary"
+	"github.com/Anthony-Bible/password-exchange/app/internal/domains/message/ports/secondary"
 	"github.com/Anthony-Bible/password-exchange/app/internal/shared/logging"
 	"github.com/gin-gonic/gin"
 	swaggerFiles "github.com/swaggo/files"
@@ -15,16 +16,21 @@ import (
 
 // WebServer handles HTTP requests for the message service
 type WebServer struct {
-	messageHandler *MessageHandler
-	messageService primary.MessageServicePort
-	apiServer      *api.Server
-	router         *gin.Engine
+	messageHandler    *MessageHandler
+	messageService    primary.MessageServicePort
+	encryptionService secondary.EncryptionServicePort
+	storageService    secondary.StorageServicePort
+	router            *gin.Engine
 }
 
-// NewWebServer creates a new web server
-func NewWebServer(messageService primary.MessageServicePort) *WebServer {
+// NewWebServer creates a new web server. The encryption and storage ports are
+// required so the root-level /readyz probe can verify downstream gRPC services.
+func NewWebServer(
+	messageService primary.MessageServicePort,
+	encryptionService secondary.EncryptionServicePort,
+	storageService secondary.StorageServicePort,
+) *WebServer {
 	messageHandler := NewMessageHandler(messageService)
-	apiServer := api.NewServer(messageService)
 
 	router := gin.Default()
 
@@ -41,10 +47,11 @@ func NewWebServer(messageService primary.MessageServicePort) *WebServer {
 	router.Static("/assets", "/templates/assets")
 
 	return &WebServer{
-		messageHandler: messageHandler,
-		messageService: messageService,
-		apiServer:      apiServer,
-		router:         router,
+		messageHandler:    messageHandler,
+		messageService:    messageService,
+		encryptionService: encryptionService,
+		storageService:    storageService,
+		router:            router,
 	}
 }
 
@@ -76,8 +83,16 @@ func (s *WebServer) SetupRoutes() {
 
 // setupAPIRoutes adds API routes to the main router
 func (s *WebServer) setupAPIRoutes() {
-	// Create API handler directly with the message service
-	apiHandler := api.NewMessageAPIHandler(s.messageService)
+	// Create API handler directly with the message service plus the two
+	// secondary ports that /readyz needs to probe.
+	apiHandler := api.NewMessageAPIHandler(s.messageService, s.encryptionService, s.storageService)
+
+	// Process-alive and dependency-aware probes live on the root, not under
+	// /api/v1 — k8s probe paths shouldn't be versioned alongside the public
+	// REST surface. They're attached to s.router (not the apiGroup) so they
+	// stay reachable at the documented /livez and /readyz paths.
+	s.router.GET("/livez", middleware.HealthCheckRateLimit(), apiHandler.Livez)
+	s.router.GET("/readyz", middleware.HealthCheckRateLimit(), apiHandler.Readyz)
 
 	// Add API middleware
 	apiGroup := s.router.Group("/api")

--- a/app/internal/domains/message/adapters/secondary/grpc_clients/encryption_client.go
+++ b/app/internal/domains/message/adapters/secondary/grpc_clients/encryption_client.go
@@ -7,12 +7,15 @@ import (
 	"github.com/Anthony-Bible/password-exchange/app/internal/shared/logging"
 	pb "github.com/Anthony-Bible/password-exchange/app/pkg/pb/encryption"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health/grpc_health_v1"
 )
+
 
 // EncryptionClient implements the EncryptionServicePort using gRPC
 type EncryptionClient struct {
-	client pb.MessageServiceClient
-	conn   *grpc.ClientConn
+	client       pb.MessageServiceClient
+	healthClient grpc_health_v1.HealthClient
+	conn         *grpc.ClientConn
 }
 
 // NewEncryptionClient creates a new encryption gRPC client
@@ -23,11 +26,10 @@ func NewEncryptionClient(endpoint string) (*EncryptionClient, error) {
 		return nil, fmt.Errorf("failed to connect to encryption service: %w", err)
 	}
 
-	client := pb.NewMessageServiceClient(conn)
-
 	return &EncryptionClient{
-		client: client,
-		conn:   conn,
+		client:       pb.NewMessageServiceClient(conn),
+		healthClient: grpc_health_v1.NewHealthClient(conn),
+		conn:         conn,
 	}, nil
 }
 
@@ -105,6 +107,14 @@ func (c *EncryptionClient) GenerateID(ctx context.Context) (string, error) {
 	id := resp.GetEncryptionString()
 	logging.Debug().Str("id", id).Msg("Generated unique ID successfully")
 	return id, nil
+}
+
+// HealthCheck queries the encryption service's standard gRPC health endpoint
+// and returns nil only when the overall service reports SERVING. Any other
+// status (including transport errors) surfaces as an error so /readyz can
+// fail the pod off the load balancer.
+func (c *EncryptionClient) HealthCheck(ctx context.Context) error {
+	return checkServing(ctx, c.healthClient, "encryption")
 }
 
 // Close closes the gRPC connection

--- a/app/internal/domains/message/adapters/secondary/grpc_clients/health.go
+++ b/app/internal/domains/message/adapters/secondary/grpc_clients/health.go
@@ -1,0 +1,22 @@
+package grpc_clients
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/grpc/health/grpc_health_v1"
+)
+
+// checkServing queries a gRPC health client and returns nil only when the
+// overall service reports SERVING. Errors are wrapped with serviceName so the
+// caller doesn't have to.
+func checkServing(ctx context.Context, healthClient grpc_health_v1.HealthClient, serviceName string) error {
+	resp, err := healthClient.Check(ctx, &grpc_health_v1.HealthCheckRequest{})
+	if err != nil {
+		return fmt.Errorf("%s health check: %w", serviceName, err)
+	}
+	if resp.GetStatus() != grpc_health_v1.HealthCheckResponse_SERVING {
+		return fmt.Errorf("%s health check returned status %s", serviceName, resp.GetStatus().String())
+	}
+	return nil
+}

--- a/app/internal/domains/message/adapters/secondary/grpc_clients/storage_client.go
+++ b/app/internal/domains/message/adapters/secondary/grpc_clients/storage_client.go
@@ -9,12 +9,14 @@ import (
 	"github.com/Anthony-Bible/password-exchange/app/internal/shared/logging"
 	db "github.com/Anthony-Bible/password-exchange/app/pkg/pb/database"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
 // StorageClient implements the StorageServicePort using gRPC
 type StorageClient struct {
-	client db.DbServiceClient
-	conn   *grpc.ClientConn
+	client       db.DbServiceClient
+	healthClient grpc_health_v1.HealthClient
+	conn         *grpc.ClientConn
 }
 
 // NewStorageClient creates a new storage gRPC client
@@ -25,11 +27,10 @@ func NewStorageClient(endpoint string) (*StorageClient, error) {
 		return nil, fmt.Errorf("failed to connect to storage service: %w", err)
 	}
 
-	client := db.NewDbServiceClient(conn)
-
 	return &StorageClient{
-		client: client,
-		conn:   conn,
+		client:       db.NewDbServiceClient(conn),
+		healthClient: grpc_health_v1.NewHealthClient(conn),
+		conn:         conn,
 	}, nil
 }
 
@@ -141,6 +142,14 @@ func (c *StorageClient) GetMessage(
 		Bool("hasPassphrase", hasPassphrase).
 		Msg("Retrieved message without incrementing view count successfully")
 	return response, nil
+}
+
+// HealthCheck queries the storage service's standard gRPC health endpoint
+// and returns nil only when the overall service reports SERVING. The storage
+// server flips its status based on real MySQL connectivity, so a NOT_SERVING
+// response here means /readyz should fail the pod off the load balancer.
+func (c *StorageClient) HealthCheck(ctx context.Context) error {
+	return checkServing(ctx, c.healthClient, "storage")
 }
 
 // Close closes the gRPC connection

--- a/app/internal/domains/message/domain/message_service_test.go
+++ b/app/internal/domains/message/domain/message_service_test.go
@@ -35,6 +35,11 @@ func (m *mockEncryptionService) GenerateID(ctx context.Context) (string, error) 
 	return args.String(0), args.Error(1)
 }
 
+func (m *mockEncryptionService) HealthCheck(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
 type mockStorageService struct{ mock.Mock }
 
 func (m *mockStorageService) StoreMessage(ctx context.Context, req MessageStorageRequest) error {
@@ -56,6 +61,11 @@ func (m *mockStorageService) GetMessage(
 ) (*MessageStorageResponse, error) {
 	args := m.Called(ctx, req)
 	return args.Get(0).(*MessageStorageResponse), args.Error(1)
+}
+
+func (m *mockStorageService) HealthCheck(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
 }
 
 type mockNotificationService struct{ mock.Mock }

--- a/app/internal/domains/message/ports/secondary/encryption.go
+++ b/app/internal/domains/message/ports/secondary/encryption.go
@@ -17,4 +17,9 @@ type EncryptionServicePort interface {
 
 	// GenerateID generates a unique identifier
 	GenerateID(ctx context.Context) (string, error)
+
+	// HealthCheck verifies the underlying encryption service is reachable and
+	// serving. Implementations SHOULD honour ctx for cancellation/timeout so
+	// the web service's /readyz probe cannot wedge on a hung backend.
+	HealthCheck(ctx context.Context) error
 }

--- a/app/internal/domains/message/ports/secondary/storage.go
+++ b/app/internal/domains/message/ports/secondary/storage.go
@@ -16,4 +16,9 @@ type StorageServicePort interface {
 
 	// GetMessage retrieves message metadata without incrementing view count
 	GetMessage(ctx context.Context, req contracts.MessageRetrievalStorageRequest) (*contracts.MessageStorageResponse, error)
+
+	// HealthCheck verifies the underlying storage service is reachable and
+	// serving. Implementations SHOULD honour ctx for cancellation/timeout so
+	// the web service's /readyz probe cannot wedge on a hung backend.
+	HealthCheck(ctx context.Context) error
 }

--- a/app/internal/domains/notification/adapters/secondary/rabbitmq/consumer.go
+++ b/app/internal/domains/notification/adapters/secondary/rabbitmq/consumer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 
 	"github.com/Anthony-Bible/password-exchange/app/internal/domains/notification/domain"
 	"github.com/Anthony-Bible/password-exchange/app/internal/domains/notification/ports/contracts"
@@ -14,8 +15,12 @@ import (
 	amqp "github.com/rabbitmq/amqp091-go"
 )
 
-// RabbitMQConsumer implements the QueuePort using RabbitMQ
+// RabbitMQConsumer implements the QueuePort using RabbitMQ.
+//
+// connection is written by Connect (consumer goroutine) and read by
+// IsConnectionAlive (HTTP /healthz goroutine), so all access goes through mu.
 type RabbitMQConsumer struct {
+	mu         sync.RWMutex
 	connection *amqp.Connection
 	channel    *amqp.Channel
 }
@@ -42,8 +47,10 @@ func (r *RabbitMQConsumer) Connect(ctx context.Context, queueConn contracts.Queu
 		return fmt.Errorf("%w: %v", domain.ErrQueueConnectionFailed, err)
 	}
 
+	r.mu.Lock()
 	r.connection = conn
 	r.channel = ch
+	r.mu.Unlock()
 
 	logging.Info().Str("host", queueConn.Host).Int("port", queueConn.Port).Msg("Connected to RabbitMQ")
 	return nil
@@ -178,11 +185,15 @@ func (r *RabbitMQConsumer) handleMessage(ctx context.Context, delivery amqp.Deli
 
 // Close closes the RabbitMQ connection
 func (r *RabbitMQConsumer) Close() error {
-	if r.channel != nil {
-		r.channel.Close()
+	r.mu.Lock()
+	ch := r.channel
+	conn := r.connection
+	r.mu.Unlock()
+	if ch != nil {
+		ch.Close()
 	}
-	if r.connection != nil {
-		r.connection.Close()
+	if conn != nil {
+		conn.Close()
 	}
 	logging.Info().Msg("RabbitMQ connection closed")
 	return nil
@@ -207,8 +218,11 @@ func isConnAlive(c connStatus) bool {
 // wedged consumer (e.g. channel closed, connection dropped) gets restarted by
 // Kubernetes instead of silently accepting deliveries it can't process.
 func (r *RabbitMQConsumer) IsConnectionAlive() bool {
-	if r.connection == nil {
+	r.mu.RLock()
+	conn := r.connection
+	r.mu.RUnlock()
+	if conn == nil {
 		return false
 	}
-	return isConnAlive(r.connection)
+	return isConnAlive(conn)
 }

--- a/app/internal/domains/storage/adapters/primary/grpc/health_test.go
+++ b/app/internal/domains/storage/adapters/primary/grpc/health_test.go
@@ -5,12 +5,14 @@ import (
 	"errors"
 	"net"
 	"testing"
+	"time"
 
 	database "github.com/Anthony-Bible/password-exchange/app/pkg/pb/database"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/test/bufconn"
 )
@@ -56,4 +58,74 @@ func TestRegisterHealthServer_OverallServiceReportsServing(t *testing.T) {
 	resp, err := client.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{Service: ""})
 	require.NoError(t, err)
 	assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.GetStatus())
+}
+
+// TestUpdateHealthStatus_FlipsToNotServingWhenDomainCheckFails verifies that
+// when StorageService.HealthCheck returns an error, the standard health
+// service reports NOT_SERVING. This is what makes the web service's /readyz
+// (which calls Check via grpc_health_v1) catch real DB outages instead of
+// just network/process failures.
+func TestUpdateHealthStatus_FlipsToNotServingWhenDomainCheckFails(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubStorageService{healthErr: errors.New("db down")}
+	server := NewGRPCServer(svc, "", &recordingLogger{}, &stubValidator{})
+
+	healthSrv := health.NewServer()
+	healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+
+	server.updateHealthStatus(context.Background(), healthSrv, time.Second)
+
+	resp, err := healthSrv.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{Service: ""})
+	require.NoError(t, err)
+	assert.Equal(t, grpc_health_v1.HealthCheckResponse_NOT_SERVING, resp.GetStatus())
+}
+
+// TestUpdateHealthStatus_FlipsBackToServingWhenDomainCheckRecovers verifies
+// that after a transient failure the next successful check restores SERVING
+// status, so a recovered DB un-trips readiness instead of staying degraded.
+func TestUpdateHealthStatus_FlipsBackToServingWhenDomainCheckRecovers(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubStorageService{healthErr: errors.New("db down")}
+	server := NewGRPCServer(svc, "", &recordingLogger{}, &stubValidator{})
+
+	healthSrv := health.NewServer()
+	healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+
+	server.updateHealthStatus(context.Background(), healthSrv, time.Second)
+	resp, err := healthSrv.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{Service: ""})
+	require.NoError(t, err)
+	require.Equal(t, grpc_health_v1.HealthCheckResponse_NOT_SERVING, resp.GetStatus())
+
+	svc.healthErr = nil
+	server.updateHealthStatus(context.Background(), healthSrv, time.Second)
+	resp, err = healthSrv.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{Service: ""})
+	require.NoError(t, err)
+	assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.GetStatus())
+}
+
+// TestRunHealthStatusLoop_ExitsOnContextCancel verifies the polling loop
+// terminates when the caller cancels the context, preventing a goroutine
+// leak at server shutdown.
+func TestRunHealthStatusLoop_ExitsOnContextCancel(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubStorageService{}
+	server := NewGRPCServer(svc, "", &recordingLogger{}, &stubValidator{})
+	healthSrv := health.NewServer()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		server.runHealthStatusLoop(ctx, healthSrv, 10*time.Millisecond, time.Second)
+		close(done)
+	}()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("runHealthStatusLoop did not return after context cancel")
+	}
 }

--- a/app/internal/domains/storage/adapters/primary/grpc/server.go
+++ b/app/internal/domains/storage/adapters/primary/grpc/server.go
@@ -24,6 +24,14 @@ import (
 // maxExpirationDuration is the maximum allowed expiration time (90 days).
 const maxExpirationDuration = 2160 * time.Hour
 
+// healthCheckInterval is how often the storage adapter probes the underlying
+// repository to refresh the standard gRPC health-service status.
+const healthCheckInterval = 10 * time.Second
+
+// healthCheckTimeout bounds a single HealthCheck call so a hung backend
+// cannot wedge the status-refresh loop.
+const healthCheckTimeout = 3 * time.Second
+
 // domainErrorToStatus maps storage-domain sentinel errors to typed gRPC
 // status codes. Without this, validation failures bubble up as codes.Unknown
 // and clients that retry on Unknown (a common default) loop forever on
@@ -297,13 +305,57 @@ func (s *GRPCServer) runExpiredMessageCleanup(ctx context.Context) {
 }
 
 // registerHealthServer wires the standard gRPC health service into the given
-// server with the overall service ("") marked SERVING. k8s grpc: probes need a
-// SERVING response on this contract to mark the pod Ready; deeper per-component
-// health (e.g. DB connectivity) is intentionally out of scope here.
-func (s *GRPCServer) registerHealthServer(grpcServer *grpc.Server) {
+// server. The initial status is SERVING so a probe arriving before the first
+// HealthCheck tick doesn't fail spuriously; the polling loop driven from
+// Start subsequently flips status based on real repository connectivity.
+func (s *GRPCServer) registerHealthServer(grpcServer *grpc.Server) *health.Server {
 	healthSrv := health.NewServer()
 	healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
 	grpc_health_v1.RegisterHealthServer(grpcServer, healthSrv)
+	return healthSrv
+}
+
+// updateHealthStatus runs a single bounded HealthCheck against the storage
+// service and forwards the result as serving status. A failure flips the
+// overall service to NOT_SERVING; a success restores SERVING. The timeout
+// applies to this individual check so a hung backend cannot block the loop.
+func (s *GRPCServer) updateHealthStatus(
+	ctx context.Context,
+	healthSrv *health.Server,
+	timeout time.Duration,
+) {
+	checkCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	if err := s.storageService.HealthCheck(checkCtx); err != nil {
+		s.logger.Warn().Err(err).Msg("Storage health check failed; reporting NOT_SERVING")
+		healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_NOT_SERVING)
+		return
+	}
+	healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+}
+
+// runHealthStatusLoop refreshes the standard health server's serving status
+// on a fixed cadence by invoking updateHealthStatus. It runs an initial check
+// immediately so the first probe after startup reflects reality, then ticks
+// until ctx is cancelled.
+func (s *GRPCServer) runHealthStatusLoop(
+	ctx context.Context,
+	healthSrv *health.Server,
+	interval, timeout time.Duration,
+) {
+	s.updateHealthStatus(ctx, healthSrv, timeout)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.updateHealthStatus(ctx, healthSrv, timeout)
+		}
+	}
 }
 
 // Start starts the gRPC server. Fatal lifecycle decisions (process exit) are
@@ -317,13 +369,15 @@ func (s *GRPCServer) Start() error {
 
 	grpcServer := grpc.NewServer()
 	database.RegisterDbServiceServer(grpcServer, s)
-	s.registerHealthServer(grpcServer)
+	healthSrv := s.registerHealthServer(grpcServer)
 	reflection.Register(grpcServer)
 
-	// Run expired message cleanup in the background; cancel it when Start returns.
+	// Run expired message cleanup and the health-status refresh loop in the
+	// background; cancel them when Start returns.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go s.runExpiredMessageCleanup(ctx)
+	go s.runHealthStatusLoop(ctx, healthSrv, healthCheckInterval, healthCheckTimeout)
 
 	s.logger.Info().Str("address", s.address).Msg("Starting gRPC storage server")
 

--- a/app/internal/domains/storage/adapters/primary/grpc/server_test.go
+++ b/app/internal/domains/storage/adapters/primary/grpc/server_test.go
@@ -95,7 +95,8 @@ func (v *stubValidator) SanitizeEmailForLogging(email string) string {
 // stubStorageService is a minimal storage service used to drive the gRPC adapter
 // down the success path so we can observe logger/validator routing.
 type stubStorageService struct {
-	storeErr error
+	storeErr  error
+	healthErr error
 }
 
 func (s *stubStorageService) StoreMessage(context.Context, *contracts.Message) error {
@@ -115,7 +116,7 @@ func (s *stubStorageService) GetReminderHistory(context.Context, int) ([]*contra
 	return nil, nil
 }
 func (s *stubStorageService) CleanupExpiredMessages(context.Context) error { return nil }
-func (s *stubStorageService) HealthCheck(context.Context) error            { return nil }
+func (s *stubStorageService) HealthCheck(context.Context) error            { return s.healthErr }
 
 // TestInsert_MapsDomainValidationErrorsToInvalidArgument verifies that domain
 // validation sentinels returned from StoreMessage surface to gRPC clients as

--- a/app/internal/domains/storage/adapters/secondary/mysql/adapter.go
+++ b/app/internal/domains/storage/adapters/secondary/mysql/adapter.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"sync/atomic"
@@ -382,6 +383,19 @@ func (m *MySQLAdapter) GetReminderHistory(messageID int) ([]*contracts.ReminderL
 
 	m.logger.Info().Int("messageID", messageID).Int("count", len(history)).Msg("Retrieved reminder history")
 	return history, nil
+}
+
+// Ping verifies the underlying *sql.DB pool can reach MySQL. The supplied
+// context bounds the call so callers (notably the gRPC health-status loop)
+// don't wedge waiting on a hung database.
+func (m *MySQLAdapter) Ping(ctx context.Context) error {
+	if err := m.requireOpen(); err != nil {
+		return err
+	}
+	if err := m.db.PingContext(ctx); err != nil {
+		return fmt.Errorf("%w: %v", domain.ErrDatabaseConnection, err)
+	}
+	return nil
 }
 
 // Close closes the database connection and marks the adapter as closed so

--- a/app/internal/domains/storage/adapters/secondary/mysql/adapter_test.go
+++ b/app/internal/domains/storage/adapters/secondary/mysql/adapter_test.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -426,6 +427,69 @@ func TestMySQLAdapter_LogReminderSent(t *testing.T) {
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("SQL expectations were not met: %v", err)
+	}
+}
+
+func TestMySQLAdapter_Ping_SuccessReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatalf("Error creating mock database: %v", err)
+	}
+	defer db.Close()
+
+	adapter := &MySQLAdapter{db: db, logger: noopLogger{}, validator: noopValidator{}}
+	mock.ExpectPing()
+
+	if err := adapter.Ping(context.Background()); err != nil {
+		t.Errorf("Ping() error = %v, want nil", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("SQL expectations were not met: %v", err)
+	}
+}
+
+func TestMySQLAdapter_Ping_SurfacesDriverError(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatalf("Error creating mock database: %v", err)
+	}
+	defer db.Close()
+
+	adapter := &MySQLAdapter{db: db, logger: noopLogger{}, validator: noopValidator{}}
+	boom := errors.New("connection refused")
+	mock.ExpectPing().WillReturnError(boom)
+
+	err = adapter.Ping(context.Background())
+	if err == nil {
+		t.Fatalf("Ping() error = nil, want non-nil")
+	}
+	if !errors.Is(err, domain.ErrDatabaseConnection) {
+		t.Errorf("expected ErrDatabaseConnection, got %v", err)
+	}
+}
+
+func TestMySQLAdapter_Ping_RejectedAfterClose(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Error creating mock database: %v", err)
+	}
+	mock.ExpectClose()
+
+	adapter := &MySQLAdapter{db: db, logger: noopLogger{}, validator: noopValidator{}}
+	if err := adapter.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	err = adapter.Ping(context.Background())
+	if !errors.Is(err, domain.ErrRepositoryClosed) {
+		t.Errorf("expected ErrRepositoryClosed, got %v", err)
 	}
 }
 

--- a/app/internal/domains/storage/domain/service.go
+++ b/app/internal/domains/storage/domain/service.go
@@ -177,10 +177,14 @@ func (s *StorageService) GetReminderHistory(ctx context.Context, messageID int) 
 	return history, nil
 }
 
-// HealthCheck verifies the storage service is healthy
+// HealthCheck verifies the storage service is healthy by probing the
+// underlying repository. The error is returned to the caller (the gRPC
+// health probe loop) so it can flip the standard health-service status.
 func (s *StorageService) HealthCheck(ctx context.Context) error {
-	// For now, just log that health check was called
-	// In a real implementation, this might check repository connectivity
-	s.logger.Debug().Msg("Storage service health check requested")
+	if err := s.repository.Ping(ctx); err != nil {
+		s.logger.Warn().Err(err).Msg("Storage health check failed")
+		return err
+	}
+	s.logger.Debug().Msg("Storage health check succeeded")
 	return nil
 }

--- a/app/internal/domains/storage/domain/service_test.go
+++ b/app/internal/domains/storage/domain/service_test.go
@@ -81,6 +81,11 @@ func (m *MockMessageRepository) Close() error {
 	return args.Error(0)
 }
 
+func (m *MockMessageRepository) Ping(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
 // MockLoggerPort is a hand-written mock implementing secondary.LoggerPort.
 type MockLoggerPort struct {
 	mock.Mock
@@ -514,10 +519,25 @@ func TestGetReminderHistory_HappyPath(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
-func TestHealthCheck_ReturnsNil(t *testing.T) {
-	svc, _, _, _ := newServiceWithMocks(t)
+func TestHealthCheck_HappyPathReturnsNil(t *testing.T) {
+	svc, repo, _, _ := newServiceWithMocks(t)
+	repo.On("Ping", mock.Anything).Return(nil).Once()
 
 	err := svc.HealthCheck(context.Background())
 
 	require.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestHealthCheck_SurfacesRepositoryPingError(t *testing.T) {
+	svc, repo, _, _ := newServiceWithMocks(t)
+
+	boom := errors.New("ping failed")
+	repo.On("Ping", mock.Anything).Return(boom).Once()
+
+	err := svc.HealthCheck(context.Background())
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, boom)
+	repo.AssertExpectations(t)
 }

--- a/app/internal/domains/storage/ports/secondary/repository.go
+++ b/app/internal/domains/storage/ports/secondary/repository.go
@@ -5,6 +5,8 @@
 package secondary
 
 import (
+	"context"
+
 	"github.com/Anthony-Bible/password-exchange/app/internal/domains/storage/ports/contracts"
 )
 
@@ -124,4 +126,14 @@ type MessageRepository interface {
 	//   - nil if the resources were released successfully
 	//   - An error if the underlying close call fails
 	Close() error
+
+	// Ping verifies that the underlying datastore is reachable. Implementations
+	// SHOULD honour ctx for cancellation and timeout so callers (notably the
+	// gRPC health probe loop) cannot wedge waiting on a hung backend.
+	//
+	// Returns:
+	//   - nil if the datastore responded successfully
+	//   - domain.ErrRepositoryClosed if Close has already been called
+	//   - An error wrapping domain.ErrDatabaseConnection if the ping fails
+	Ping(ctx context.Context) error
 }

--- a/k8s/email.deployment.yaml
+++ b/k8s/email.deployment.yaml
@@ -52,4 +52,12 @@ spec:
           periodSeconds: 30
           timeoutSeconds: 5
           failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
 

--- a/k8s/password-exchange.deployment.yaml
+++ b/k8s/password-exchange.deployment.yaml
@@ -60,10 +60,13 @@ spec:
         - containerPort: 8080
           name: http
           protocol: TCP
-        # Health checks for API endpoints
+        # /livez: process-alive only — restarts the pod when the Go runtime
+        # is wedged. /readyz: dependency-aware, fans out to the encryption
+        # and storage gRPC services under a 2s in-handler deadline, so the
+        # 3s probe timeout below leaves a small budget on top.
         livenessProbe:
           httpGet:
-            path: /api/v1/health
+            path: /livez
             port: 8080
           initialDelaySeconds: 30
           periodSeconds: 30
@@ -71,7 +74,7 @@ spec:
           failureThreshold: 3
         readinessProbe:
           httpGet:
-            path: /api/v1/health
+            path: /readyz
             port: 8080
           initialDelaySeconds: 5
           periodSeconds: 10

--- a/k8s/slackbot.deployment.yaml
+++ b/k8s/slackbot.deployment.yaml
@@ -26,6 +26,24 @@ spec:
       - image: ghcr.io/anthony-bible/passwordexchange-slackbot-%{PHASE}@%{SLACKBOT_IMAGE_SHA}
         ports:
         - containerPort: 3000
+        # Process-alive probe only — Slack/DB outages should not cascade
+        # into restart loops here.
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 3000
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 3000
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
         env:
           - name: PASSWORDEXCHANGE_ENCRYPTIONSERVICE
             valueFrom:

--- a/slackbot/program.py
+++ b/slackbot/program.py
@@ -181,6 +181,13 @@ def update_home_tab(client, event, logger):
         )
     except Exception as e:
         logger.error(f"Error publishing home tab: {e}")
+@app.route("/healthz", methods=["GET"])
+def healthz():
+    # Dependency-free process-alive probe for k8s. Intentionally does NOT
+    # poke Slack or the OAuth DB — those would cascade into restart loops
+    # during transient upstream blips.
+    return {"status": "ok"}, 200
+
 @app.route("/slack/events", methods=["POST"])
 def slack_events():
     """ Declaring the route where slack will post a request """


### PR DESCRIPTION
## Summary

Finishes the P1 portion of #468 on top of the merged P0 work (#469).

- **web**: split the single fake `/api/v1/health` probe into `/livez` (process-alive, never touches deps) and `/readyz` (fans out to encryption + storage `HealthCheck` under a 2s deadline; 503 + JSON naming the failed dep(s) on failure). Routes live on the root, not under `/api/v1`.
- **storage gRPC**: `SetServingStatus` is now driven by real MySQL connectivity — a ~10s polling loop calls `StorageService.HealthCheck` (which delegates to a new `MessageRepository.Ping`) with a 3s per-call timeout and flips the standard health service between `SERVING` and `NOT_SERVING` accordingly. The dead `HealthCheck` stub the issue called out is now wired through.
- **encryption gRPC**: status stays hardcoded `SERVING` — key generation is pure in-process so process-alive ≡ service-healthy. Comment added to document that.
- **slackbot**: new dependency-free `/healthz` Flask route + matching k8s liveness/readiness probes on :3000.
- **k8s**: web deployment now points at `/livez` and `/readyz`; slackbot deployment gains probe blocks matching the other services' shape.

P2 (email `containerPort: 8080` audit item) is moot — P0 actually wired an HTTP server on :8080 for `/healthz`, so the port declaration is now accurate.

## Test plan

- [x] `go test ./...` — full Go suite green, including 9 new tests:
  - 3 in `storage/adapters/secondary/mysql` for `Ping` (happy path, driver-error wrapping, post-Close rejection)
  - 2 in `storage/domain` replacing the no-op `HealthCheck` test (happy path + surfaces Ping error)
  - 3 in `storage/adapters/primary/grpc` for the status-update loop (flip to `NOT_SERVING`, flip back to `SERVING`, exit on context cancel)
  - 6 in `message/adapters/primary/api` for the new handlers (Livez never touches deps, Readyz returns 200/503 across all dep combinations, Readyz respects the 2s context deadline)
- [x] `combined.yaml` substitution verified locally — web probes hit `/livez`/`/readyz` on :8080, slackbot probes hit `/healthz` on :3000, P0's storage/encryption gRPC probes still on :50051.
- [ ] Manual probe smoke test against dev cluster after deploy:
  - `curl <web>/livez` → 200 even with DB down
  - `curl <web>/readyz` → 200 when healthy, 503 within ~15s of killing the database service
  - `curl <slackbot>/healthz` → 200 `{"status":"ok"}`
- [ ] Watch pod restart counts on dev for a day after rollout — no regressions from the tighter readiness gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)