### PR TITLE
fix: remove duplicated MaxViewCount cap (#465) and dead Config.Database field (#464)

### DIFF
--- a/app/internal/domains/storage/domain/errors.go
+++ b/app/internal/domains/storage/domain/errors.go
@@ -18,8 +18,10 @@ var (
 	// ErrInvalidParameter is returned when a parameter is invalid
 	ErrInvalidParameter = errors.New("invalid parameter")
 	
-	// ErrInvalidMaxViewCount is returned when max view count is invalid
-	ErrInvalidMaxViewCount = errors.New("max view count must be between 1 and 100")
+	// ErrInvalidMaxViewCount is returned when max view count is below the
+	// structural minimum of 1. The upper bound is a product policy enforced by
+	// the message domain (message.AbsoluteMaxViewCount), not by storage.
+	ErrInvalidMaxViewCount = errors.New("max view count must be at least 1")
 	
 	// ErrMessageNotFound is returned when a message is not found in storage
 	ErrMessageNotFound = errors.New("message not found")

--- a/app/internal/domains/storage/domain/service.go
+++ b/app/internal/domains/storage/domain/service.go
@@ -55,7 +55,11 @@ func (s *StorageService) StoreMessage(ctx context.Context, message *contracts.Me
 		s.logger.Warn().Msg("Attempted to store message with empty unique ID")
 		return ErrEmptyUniqueID
 	}
-	if message.MaxViewCount < 1 || message.MaxViewCount > 100 {
+	// Storage only guards the structurally invalid case (< 1). The upper bound
+	// is a product policy owned by the message domain (message.AbsoluteMaxViewCount),
+	// so callers are responsible for enforcing it; duplicating the cap here would
+	// silently reject otherwise-valid counts if that policy ever changes.
+	if message.MaxViewCount < 1 {
 		s.logger.Warn().Int("maxViewCount", message.MaxViewCount).Msg("Attempted to store message with invalid max view count")
 		return ErrInvalidMaxViewCount
 	}

--- a/app/internal/domains/storage/domain/service_test.go
+++ b/app/internal/domains/storage/domain/service_test.go
@@ -277,7 +277,7 @@ func TestStoreMessage_RejectsInvalidMaxViewCount(t *testing.T) {
 		maxViewCount int
 	}{
 		{name: "below minimum", maxViewCount: 0},
-		{name: "above maximum", maxViewCount: 101},
+		{name: "negative", maxViewCount: -1},
 	}
 
 	for _, tc := range tests {
@@ -295,6 +295,25 @@ func TestStoreMessage_RejectsInvalidMaxViewCount(t *testing.T) {
 			repo.AssertNotCalled(t, "InsertMessage", mock.Anything)
 		})
 	}
+}
+
+// The upper bound on view count is a policy owned by the message domain
+// (message.AbsoluteMaxViewCount). Storage only guards against the structurally
+// invalid case of a count below 1, so a high count delegates to the repository.
+func TestStoreMessage_AcceptsHighMaxViewCount(t *testing.T) {
+	svc, repo, _, _ := newServiceWithMocks(t)
+
+	msg := &contracts.Message{
+		Content:      "ciphertext",
+		UniqueID:     "abc",
+		MaxViewCount: 101,
+	}
+	repo.On("InsertMessage", msg).Return(nil).Once()
+
+	err := svc.StoreMessage(context.Background(), msg)
+
+	require.NoError(t, err)
+	repo.AssertExpectations(t)
 }
 
 func TestStoreMessage_ValidInputDelegatesToRepository(t *testing.T) {

--- a/app/internal/shared/config/config.go
+++ b/app/internal/shared/config/config.go
@@ -1,9 +1,5 @@
 package config
 
-import (
-	"github.com/Anthony-Bible/password-exchange/app/internal/domains/storage/ports/contracts"
-)
-
 var AppConfig PassConfig
 
 // EmailConfig holds all email-related settings.
@@ -39,12 +35,18 @@ type EmailSender struct {
 	Name  string `mapstructure:"name"`
 }
 
-// Config represents the complete application configuration
+// Config represents the complete application configuration.
+//
+// Database connection settings live on the flat PassConfig.Db* fields
+// (consumed by cmd/database and cmd/reminder). There is intentionally no
+// structured `database:` block: a previous Config.Database field was loaded by
+// viper but never read, so any `database:` YAML or PASSWORDEXCHANGE_DATABASE_*
+// env var was silently dropped. It was removed rather than wired up to avoid
+// that invisible-misconfiguration trap.
 type Config struct {
 	PassConfig `mapstructure:",squash"`
-	Database   contracts.DatabaseConfig `mapstructure:"database"`
-	Reminder   ReminderConfig        `mapstructure:"reminder"`
-	Email      EmailConfig           `mapstructure:"email"`
+	Reminder   ReminderConfig `mapstructure:"reminder"`
+	Email      EmailConfig    `mapstructure:"email"`
 }
 
 // ReminderConfig contains configuration for the reminder email system


### PR DESCRIPTION
Closes #464, closes #465. Two low-risk follow-ups from the PR #461 storage-refactor review.

## #465 — duplicated `MaxViewCount` upper bound
The storage domain enforced `MaxViewCount > 100` as a second, unlinked copy of `message.AbsoluteMaxViewCount`. Raising the message-domain cap would leave storage silently rejecting valid counts with a misleading error.

**Fix (Option 2 — domain validation at the edge):** storage now only guards the structurally invalid `< 1` case; the upper bound is owned by the message domain. `ErrInvalidMaxViewCount` message updated to "must be at least 1". The `101` test case now asserts storage *accepts* the high count and delegates to the repository.

## #464 — unread `Config.Database` field
`Config.Database` was loaded by viper but never consumed (both `cmd/database` and `cmd/reminder` build their `DatabaseConfig` from the flat `PassConfig.Db*` fields). Any `database:` YAML block or `PASSWORDEXCHANGE_DATABASE_*` env var was silently dropped.

**Fix (Option 1 — drop it):** removed the field + orphaned import, and documented on `Config` why there is no structured `database:` block.

## Verification
- `go build ./...` clean
- full `go test ./...` → 26/26 packages pass

## Note (out of scope)
`test_max_view_count.go` at the repo root is a committed, broken orphan (`package main`, unresolvable imports, doesn't compile, invisible to `go test ./...`). Left untouched here — flagging for a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)