### PR TITLE
fix(deps): bump go-viper/mapstructure to v2.4.0 (CVE-2025-11065)

### DIFF
--- a/app/go.mod
+++ b/app/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/go-openapi/swag v0.19.15 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/go-viper/mapstructure/v2 v2.3.0 // indirect
+	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/app/go.sum
+++ b/app/go.sum
@@ -94,8 +94,8 @@ github.com/go-playground/validator/v10 v10.26.0 h1:SP05Nqhjcvz81uJaRfEV0YBSSSGMc
 github.com/go-playground/validator/v10 v10.26.0/go.mod h1:I5QpIEbmr8On7W0TktmJAumgzX4CA1XNl4ZmDuVHKKo=
 github.com/go-sql-driver/mysql v1.9.2 h1:4cNKDYQ1I84SXslGddlsrMhc8k4LeDVj6Ad6WRjiHuU=
 github.com/go-sql-driver/mysql v1.9.2/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI64Gl8i5p1WMU=
-github.com/go-viper/mapstructure/v2 v2.3.0 h1:27XbWsHIqhbdR5TIC911OfYvgSaW93HM+dX7970Q7jk=
-github.com/go-viper/mapstructure/v2 v2.3.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
+github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
 github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=


### PR DESCRIPTION
## Summary
Resolves **CVE-2025-11065** (Medium, CVSS 5.3) reported in #427.

`github.com/go-viper/mapstructure/v2` **v2.3.0** can disclose sensitive input values through detailed error messages during `mapstructure.WeakDecode`. The library is pulled in transitively via `github.com/spf13/viper v1.20.1`.

This bumps it to **v2.4.0**, which contains the upstream fix.

## Details
- `app/go.mod`: `go-viper/mapstructure/v2 v2.3.0 // indirect` → `v2.4.0 // indirect`
- `app/go.sum`: hashes updated for v2.4.0
- The `/go.mod` hash is identical between v2.3.0 and v2.4.0, so **no new transitive dependencies** are introduced — a clean, low-risk patch bump.

## Verification
- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./...` ✅ (26 packages, 0 failures)

Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)