### PR TITLE
fix(observability): replace hardcoded /api/v1/health with real dependency checks (#475)

### DIFF
--- a/app/api/openapi.yaml
+++ b/app/api/openapi.yaml
@@ -484,7 +484,7 @@ components:
       properties:
         status:
           type: string
-          enum: [healthy, unhealthy]
+          enum: [healthy, degraded, unhealthy]
           description: Overall system health status
           example: "healthy"
         version:
@@ -505,7 +505,6 @@ components:
           example:
             database: "healthy"
             encryption: "healthy"
-            email: "healthy"
 
     APIInfoResponse:
       type: object

--- a/app/api/openapi.yaml
+++ b/app/api/openapi.yaml
@@ -284,7 +284,6 @@ paths:
                     services:
                       database: "healthy"
                       encryption: "healthy"
-                      email: "healthy"
 
   /info:
     get:

--- a/app/internal/domains/message/adapters/primary/api/handlers.go
+++ b/app/internal/domains/message/adapters/primary/api/handlers.go
@@ -21,6 +21,11 @@ import (
 // up behind a wedged dependency.
 const readyzTimeout = 2 * time.Second
 
+// healthCheckTimeout bounds how long the public /api/v1/health endpoint waits
+// on its downstream dependency checks. Unlike readyzTimeout this is not a k8s
+// probe, so it can be a touch more lenient.
+const healthCheckTimeout = 5 * time.Second
+
 // MessageAPIHandler handles REST API requests for message operations
 type MessageAPIHandler struct {
 	messageService    primary.MessageServicePort
@@ -340,16 +345,60 @@ func (h *MessageAPIHandler) HealthCheck(c *gin.Context) {
 		Interface("correlation_id", correlationID).
 		Msg("Health check requested")
 
-	// TODO: Implement actual health checks for services
+	ctx, cancel := context.WithTimeout(c.Request.Context(), healthCheckTimeout)
+	defer cancel()
+
+	var (
+		wg       sync.WaitGroup
+		mu       sync.Mutex
+		services = make(map[string]string)
+	)
+
+	checks := []struct {
+		name string
+		fn   func(context.Context) error
+	}{
+		// "database" is reported by the storage gRPC client port.
+		{"database", h.storageService.HealthCheck},
+		{"encryption", h.encryptionService.HealthCheck},
+	}
+
+	for _, check := range checks {
+		wg.Add(1)
+		go func(name string, fn func(context.Context) error) {
+			defer wg.Done()
+			status := "healthy"
+			if err := fn(ctx); err != nil {
+				status = "unhealthy"
+				logging.Warn().Err(err).Str("dep", name).Msg("Health check dependency failed")
+			}
+			mu.Lock()
+			services[name] = status
+			mu.Unlock()
+		}(check.name, check.fn)
+	}
+	wg.Wait()
+
+	failed := 0
+	for _, status := range services {
+		if status == "unhealthy" {
+			failed++
+		}
+	}
+
+	overall := "healthy"
+	switch {
+	case failed == len(services):
+		overall = "unhealthy"
+	case failed > 0:
+		overall = "degraded"
+	}
+
 	response := models.HealthCheckResponse{
-		Status:    "healthy",
+		Status:    overall,
 		Version:   "1.0.0", // TODO: Get from build info
 		Timestamp: time.Now(),
-		Services: map[string]string{
-			"database":   "healthy", // TODO: Check database service
-			"encryption": "healthy", // TODO: Check encryption service
-			"email":      "healthy", // TODO: Check email service
-		},
+		Services:  services,
 	}
 
 	c.JSON(http.StatusOK, response)

--- a/app/internal/domains/message/adapters/primary/api/handlers_test.go
+++ b/app/internal/domains/message/adapters/primary/api/handlers_test.go
@@ -296,9 +296,103 @@ func TestHealthCheck(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "healthy", response.Status)
 	assert.Equal(t, "1.0.0", response.Version)
-	assert.Contains(t, response.Services, "database")
-	assert.Contains(t, response.Services, "encryption")
-	assert.Contains(t, response.Services, "email")
+	assert.Equal(t, "healthy", response.Services["database"])
+	assert.Equal(t, "healthy", response.Services["encryption"])
+	assert.NotContains(t, response.Services, "email")
+}
+
+func TestHealthCheck_DegradedWhenStorageUnhealthy(t *testing.T) {
+	mockService := new(MockMessageService)
+	enc := &stubEncryptionPort{healthCheck: func(context.Context) error { return nil }}
+	stor := &stubStoragePort{healthCheck: func(context.Context) error { return errors.New("storage down") }}
+	router := setupTestRouterWithProbes(mockService, enc, stor)
+
+	req, _ := http.NewRequest("GET", "/api/v1/health", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response models.HealthCheckResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	assert.Equal(t, "degraded", response.Status)
+	assert.Equal(t, "unhealthy", response.Services["database"])
+	assert.Equal(t, "healthy", response.Services["encryption"])
+}
+
+func TestHealthCheck_DegradedWhenEncryptionUnhealthy(t *testing.T) {
+	mockService := new(MockMessageService)
+	enc := &stubEncryptionPort{healthCheck: func(context.Context) error { return errors.New("encryption down") }}
+	stor := &stubStoragePort{healthCheck: func(context.Context) error { return nil }}
+	router := setupTestRouterWithProbes(mockService, enc, stor)
+
+	req, _ := http.NewRequest("GET", "/api/v1/health", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response models.HealthCheckResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	assert.Equal(t, "degraded", response.Status)
+	assert.Equal(t, "healthy", response.Services["database"])
+	assert.Equal(t, "unhealthy", response.Services["encryption"])
+}
+
+func TestHealthCheck_UnhealthyWhenAllDown(t *testing.T) {
+	mockService := new(MockMessageService)
+	enc := &stubEncryptionPort{healthCheck: func(context.Context) error { return errors.New("encryption down") }}
+	stor := &stubStoragePort{healthCheck: func(context.Context) error { return errors.New("storage down") }}
+	router := setupTestRouterWithProbes(mockService, enc, stor)
+
+	req, _ := http.NewRequest("GET", "/api/v1/health", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response models.HealthCheckResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	assert.Equal(t, "unhealthy", response.Status)
+	assert.Equal(t, "unhealthy", response.Services["database"])
+	assert.Equal(t, "unhealthy", response.Services["encryption"])
+}
+
+func TestHealthCheck_AbortsViaContextTimeout(t *testing.T) {
+	// A stuck dependency must not hang the public health endpoint. The handler
+	// attaches a deadline to the dispatched context; the stub blocks until that
+	// fires and then returns ctx.Err(), so /api/v1/health must still respond
+	// (200, that dep marked "unhealthy") rather than blocking indefinitely.
+	mockService := new(MockMessageService)
+	enc := &stubEncryptionPort{healthCheck: func(ctx context.Context) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}}
+	stor := &stubStoragePort{healthCheck: func(context.Context) error { return nil }}
+	router := setupTestRouterWithProbes(mockService, enc, stor)
+
+	req, _ := http.NewRequest("GET", "/api/v1/health", nil)
+	w := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		router.ServeHTTP(w, req)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("/api/v1/health blocked past the in-handler deadline")
+	}
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response models.HealthCheckResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	assert.Equal(t, "degraded", response.Status)
+	assert.Equal(t, "unhealthy", response.Services["encryption"])
+	assert.Equal(t, "healthy", response.Services["database"])
 }
 
 func TestAPIInfo(t *testing.T) {


### PR DESCRIPTION
## Summary

`GET /api/v1/health` returned a hardcoded `"healthy"` status for every dependency regardless of actual state, so anything monitoring this public endpoint (uptime checks, dashboards, humans) got a false-positive "all healthy" even when storage or encryption was down — delaying incident response.

This delegates to the same secondary-port `HealthCheck` methods already wired into `/readyz`, instead of hardcoding. Scope is **only** the public `/api/v1/health` JSON endpoint; the k8s `/livez` and `/readyz` probes are unchanged.

## Behavior

- Probes `storage` (reported as `"database"`) and `encryption` in parallel under a bounded 5s context, mirroring the `Readyz` pattern.
- Each dep resolves to `"healthy"` / `"unhealthy"`; failures log a `Warn` with the dep name + error.
- Three-tier overall `Status`: `"healthy"` (all pass) / `"degraded"` (some fail) / `"unhealthy"` (all fail).
- Always returns `200` with a detailed body — `/readyz` owns the 503-for-LB behavior.
- The `"email"` key is dropped: the web service has no email/queue port to probe.
- `Version` stays hardcoded `"1.0.0"` (build-info wiring is tracked separately).

## Tests

- Updated `TestHealthCheck` (per-service `"healthy"`, `NotContains "email"`).
- Added `TestHealthCheck_DegradedWhenStorageUnhealthy`, `_DegradedWhenEncryptionUnhealthy`, `_UnhealthyWhenAllDown`, and `_AbortsViaContextTimeout` (a blocked dep must not hang the endpoint).

## Verification

```
cd app && go test ./... && go build -o app .
```

All tests pass; build clean.

Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)