### PR TITLE
feat(ux): consolidate message and file share into a single URL

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,4 @@
+{
+    "esversion": 6,
+    "browser": true
+}

--- a/app/templates/assets/js/file-upload.js
+++ b/app/templates/assets/js/file-upload.js
@@ -189,6 +189,32 @@ function buildFileShareURL(fileID, encodedKey, origin) {
 }
 
 /**
+ * buildCombinedShareURL appends file params to a message share URL so the
+ * recipient can download the attached file from the same link.
+ *
+ * @param {string} messageWebUrl  The message share URL (e.g. result.webUrl)
+ * @param {string} fileID
+ * @param {string} encodedKey
+ */
+function buildCombinedShareURL(messageWebUrl, fileID, encodedKey) {
+    return messageWebUrl + '#fid=' + encodeURIComponent(fileID) + '&fk=' + encodedKey;
+}
+
+/**
+ * extractCombinedFileParams reads the fid/fk params embedded in the current
+ * page's URL fragment by buildCombinedShareURL.
+ *
+ * Returns { fileID, encodedKey } or null if either value is absent.
+ */
+function extractCombinedFileParams() {
+    const params = new URLSearchParams(window.location.hash.slice(1));
+    const fileID = params.get('fid');
+    const encodedKey = params.get('fk');
+    if (!fileID || !encodedKey) return null;
+    return { fileID: decodeURIComponent(fileID), encodedKey };
+}
+
+/**
  * extractFileDownloadParams parses the current page URL to recover the fileID
  * and encodedKey needed to call the download API.
  *
@@ -348,7 +374,9 @@ function initializeFileUpload(container, getMessageID) {
     // Expose an async function that the form-submit handler can await.
     // Returns { fileID, encodedKey, shareURL } on success, null if no file was
     // selected. Throws on error.
-    container.runUpload = async function (messageID) {
+    // opts.showResult (default true) controls whether the built-in result URL
+    // banner is shown; pass false when the caller embeds the URL elsewhere.
+    container.runUpload = async function (messageID, opts) {
         const file = fileInput.files && fileInput.files[0];
         if (!file) return null;
 
@@ -371,7 +399,7 @@ function initializeFileUpload(container, getMessageID) {
             const shareURL = buildFileShareURL(fileID, encodedKey);
 
             if (resultUrl) resultUrl.value = shareURL;
-            if (resultSection) resultSection.style.display = 'block';
+            if (resultSection && (!opts || opts.showResult !== false)) resultSection.style.display = 'block';
 
             return { fileID, encodedKey, shareURL };
         } catch (err) {

--- a/app/templates/decryption.html
+++ b/app/templates/decryption.html
@@ -334,6 +334,7 @@ function handleDecryptionSuccess(data) {
             fileBtn.disabled = true;
             fileBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>Downloading…';
             fileStatus.textContent = 'Decrypting and downloading…';
+            fileStatus.classList.remove('text-danger');
             fileStatus.style.display = 'block';
             try {
                 await fetchAndSaveFile(combinedFileParams.fileID, combinedFileParams.encodedKey);

--- a/app/templates/decryption.html
+++ b/app/templates/decryption.html
@@ -72,6 +72,23 @@
                         </small>
                     </div>
                 </div>
+
+                <div id="file-section" class="mt-4" style="display:none;">
+                    <hr>
+                    <div class="alert alert-info d-flex align-items-start">
+                        <i class="fas fa-paperclip me-3 fs-5 mt-1"></i>
+                        <div>
+                            <strong>Attached File</strong><br>
+                            <small>Click below to decrypt and download the file attached to this message.</small>
+                        </div>
+                    </div>
+                    <div class="d-grid">
+                        <button type="button" id="file-download-btn" class="btn btn-primary">
+                            <i class="fas fa-download me-2"></i>Download Attached File
+                        </button>
+                        <p id="file-download-status" class="form-text text-center mt-2" style="display:none;"></p>
+                    </div>
+                </div>
             </div>
         </div>
 
@@ -145,6 +162,9 @@
 </div>
 
 <script>
+// Parse once — the hash never changes during the page's lifetime.
+const combinedFileParams = extractCombinedFileParams();
+
 document.addEventListener('DOMContentLoaded', function() {
     // Initialize tooltips
     const tooltipElements = document.querySelectorAll('[data-bs-toggle="tooltip"]');
@@ -161,7 +181,7 @@ document.addEventListener('DOMContentLoaded', function() {
         showError('Invalid URL format. Please check the link and try again.');
         return;
     }
-    
+
     // Try to decrypt message directly without passphrase first
     decryptMessage(messageId, key, '');
     
@@ -303,6 +323,31 @@ function handleDecryptionSuccess(data) {
     // Auto-resize textarea to fit content (must happen after element is visible)
     messageInput.style.height = 'auto';
     messageInput.style.height = messageInput.scrollHeight + 'px';
+
+    // Show file download section if the share URL contains embedded file params
+    if (combinedFileParams) {
+        document.getElementById('file-section').style.display = 'block';
+        const fileBtn = document.getElementById('file-download-btn');
+        const fileStatus = document.getElementById('file-download-status');
+        // Use onclick to avoid stacking handlers if decryption succeeds after a retry.
+        fileBtn.onclick = async function () {
+            fileBtn.disabled = true;
+            fileBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>Downloading…';
+            fileStatus.textContent = 'Decrypting and downloading…';
+            fileStatus.style.display = 'block';
+            try {
+                await fetchAndSaveFile(combinedFileParams.fileID, combinedFileParams.encodedKey);
+                fileBtn.innerHTML = '<i class="fas fa-check me-2"></i>Downloaded';
+                fileBtn.classList.replace('btn-primary', 'btn-success');
+                fileStatus.textContent = 'File saved — check your downloads folder.';
+            } catch (err) {
+                fileBtn.disabled = false;
+                fileBtn.innerHTML = '<i class="fas fa-download me-2"></i>Download Attached File';
+                fileStatus.textContent = 'Download failed: ' + err.message;
+                fileStatus.classList.add('text-danger');
+            }
+        };
+    }
 }
 
 // UI Helper Functions

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -934,21 +934,22 @@ document.addEventListener('DOMContentLoaded', function() {
             
             if (response.ok) {
                 // Attempt optional file upload now that we have a messageID.
-                let fileShareURL = null;
+                let uploadResult = null;
                 const fileUploadSection = document.getElementById('file-upload-section');
                 if (fileUploadSection && typeof fileUploadSection.runUpload === 'function') {
                     try {
                         submitButton.innerHTML = '<i class="fas fa-spinner fa-spin me-2"></i>Uploading file…';
-                        const uploadResult = await fileUploadSection.runUpload(result.messageId);
-                        if (uploadResult) {
-                            fileShareURL = uploadResult.shareURL;
-                        }
+                        uploadResult = await fileUploadSection.runUpload(result.messageId, { showResult: false });
                     } catch (fileErr) {
                         // File upload failure is non-fatal: the message was already created.
                         // The file-upload-section already shows its own error state.
                         console.warn('File upload failed:', fileErr);
                     }
                 }
+
+                const shareURL = uploadResult
+                    ? buildCombinedShareURL(result.webUrl, uploadResult.fileID, uploadResult.encodedKey)
+                    : result.webUrl;
 
                 // Success - show the secure link
                 const successDiv = document.getElementById('success');
@@ -959,10 +960,10 @@ document.addEventListener('DOMContentLoaded', function() {
                             Secure Link Created Successfully!
                         </h5>
                         <hr>
-                        <p class="mb-3">Your secure message has been encrypted and is ready to share:</p>
+                        <p class="mb-3">Share this secure link with the recipient:</p>
                         <div class="input-group mb-3">
                             <input type="text" class="form-control font-monospace"
-                                   value="${result.webUrl}"
+                                   value="${shareURL}"
                                    id="secure-url" readonly>
                             <button class="btn btn-outline-secondary"
                                     type="button" onclick="copyToClipboard()"
@@ -970,22 +971,6 @@ document.addEventListener('DOMContentLoaded', function() {
                                 <i class="fas fa-copy"></i>
                             </button>
                         </div>
-                        ${fileShareURL ? `
-                        <p class="mb-2 fw-bold">
-                            <i class="fas fa-paperclip me-1"></i>
-                            File download link (share this with the recipient):
-                        </p>
-                        <div class="input-group mb-3">
-                            <input type="text" class="form-control font-monospace"
-                                   value="${fileShareURL}"
-                                   id="file-share-url" readonly>
-                            <button class="btn btn-outline-secondary"
-                                    type="button"
-                                    onclick="(function(){const el=document.getElementById('file-share-url');navigator.clipboard.writeText(el.value).catch(()=>{el.select();document.execCommand('copy')});})()"
-                                    title="Copy file link">
-                                <i class="fas fa-copy"></i>
-                            </button>
-                        </div>` : ''}
                         ${result.notificationSent ?
                             '<p class="mb-0 text-success"><i class="fas fa-envelope-check me-1"></i>Email notification sent successfully!</p>' :
                             ''}


### PR DESCRIPTION
## Summary

- When a message is submitted with an attached file, the success screen now shows **one combined URL** instead of two separate links
- The file's `fileID` and `encodedKey` are embedded in the message URL fragment: `/decrypt/{msgID}/{msgKey}#fid={fileID}&fk={encodedKey}`
- The decrypt page reads those fragment params after decryption and renders an **"Attached File" download section** — no backend changes required
- The stale `file-upload-result-section` is now hidden after upload so the old duplicate URL no longer lingers on the submit page

## Test plan

- [ ] Submit a message **with** a file attached → success card shows one URL containing `#fid=…&fk=…`; old file result section is hidden
- [ ] Open the combined URL in a fresh tab → message decrypts normally; "Attached File" section appears below
- [ ] Click "Download Attached File" → file downloads and decrypts correctly
- [ ] Submit a message **without** a file → success card shows plain message URL; decrypt page shows no file section
- [ ] Confirm text-only messages decrypt with no visible change

🤖 Generated with [Claude Code](https://claude.com/claude-code)