### PR TITLE
feat(ux): display phonetic alphabet labels below password character bubbles

### DIFF
--- a/app/assets/js/password-generator.js
+++ b/app/assets/js/password-generator.js
@@ -377,11 +377,26 @@ function initializePasswordGenerator() {
 
         const fragment = document.createDocumentFragment();
         password.split('').forEach(char => {
+            const wrapper = document.createElement('div');
+            wrapper.className = 'd-flex flex-column align-items-center';
+            wrapper.style.gap = '2px';
+
             const badge = document.createElement('span');
             badge.className = 'badge bg-light text-dark border font-monospace';
             badge.textContent = char;
-            badge.title = getPhoneticLabel(char);
-            fragment.appendChild(badge);
+
+            const phonetic = document.createElement('span');
+            phonetic.className = 'text-muted';
+            phonetic.style.fontSize = '0.6rem';
+            phonetic.style.lineHeight = '1';
+            phonetic.style.maxWidth = '3.5rem';
+            phonetic.style.textAlign = 'center';
+            phonetic.style.wordBreak = 'break-word';
+            phonetic.textContent = getPhoneticLabel(char);
+
+            wrapper.appendChild(badge);
+            wrapper.appendChild(phonetic);
+            fragment.appendChild(wrapper);
         });
         phoneticPreview.appendChild(fragment);
     }

--- a/app/assets/js/password-generator.js
+++ b/app/assets/js/password-generator.js
@@ -350,7 +350,10 @@ const PHONETIC_MAP = {
 
 function getPhoneticLabel(char) {
     const upper = char.toUpperCase();
-    return PHONETIC_MAP[upper] || char;
+    const label = PHONETIC_MAP[upper] || char;
+    if (/[A-Z]/.test(char)) return 'cap. ' + label;
+    if (/[a-z]/.test(char)) return label.toLowerCase();
+    return label;
 }
 
 // Initialize password generator functionality

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -608,7 +608,7 @@
                                 <i class="fas fa-copy"></i>
                             </button>
                         </div>
-                        <div id="phonetic-preview" class="mb-3 d-flex flex-wrap align-items-center gap-1 small text-muted"></div>
+                        <div id="phonetic-preview" class="mb-3 d-flex flex-wrap align-items-start gap-2 small text-muted"></div>
                         
                         <!-- Password Strength Meter -->
                         <div class="mb-3">


### PR DESCRIPTION

Previously the phonetic labels (Alpha, Bravo, etc.) were only visible on hover. Each character bubble now permanently shows its NATO phonetic word beneath it, making passwords easier to read aloud or transcribe.