### PR TITLE
feat(ux): add phonetic alphabet preview to decryption page

### DIFF
--- a/app/templates/assets/js/password-generator.js
+++ b/app/templates/assets/js/password-generator.js
@@ -59,7 +59,7 @@ async function loadEFFWordList() {
     showWordlistStatus('loading');
     
     try {
-        const response = await fetch('./eff_large_wordlist.txt');
+        const response = await fetch('/assets/eff_large_wordlist.txt');
         if (!response.ok) {
             throw new Error(`Failed to fetch wordlist: ${response.status} ${response.statusText}`);
         }


### PR DESCRIPTION
## Summary

- Adds a **Show/Hide Phonetic** toggle button below the decrypted message textarea so recipients can phonetically spell out passwords aloud (NATO alphabet, e.g. "cap. Mike", "victor")
- Extracts `renderPhoneticPreview(text, containerEl)` as a global function in `password-generator.js` so it can be reused outside the generator modal
- Removes the duplicate `app/assets/js/password-generator.js` — Gin only serves from `app/templates/assets/`; the two copies were a maintenance hazard
- Fixes a 404 on `/eff_large_wordlist.txt`: the relative `./` fetch path broke on non-root pages; changed to the absolute `/assets/eff_large_wordlist.txt`

## Test plan

- [ ] Open a decryption link — confirm **Show Phonetic** button appears after successful decryption
- [ ] Click the button — character bubbles with cap./lowercase phonetic labels render below the textarea
- [ ] Click again — bubbles hide and button text reverts to "Show Phonetic"
- [ ] Open the password generator modal on the submission page — confirm phonetic preview still renders correctly there
- [ ] Verify no 404 in the network tab for `eff_large_wordlist.txt` on any page

🤖 Generated with [Claude Code](https://claude.com/claude-code)