### PR TITLE
fix(api): stop rate limiting /livez and /readyz probes

### DIFF
--- a/app/internal/domains/message/adapters/primary/api/server.go
+++ b/app/internal/domains/message/adapters/primary/api/server.go
@@ -110,10 +110,12 @@ func setupRouter(
 
 	// Process-alive (/livez) and dependency-aware (/readyz) probes live on the
 	// root, not under /api/v1, so k8s probes don't get versioned along with
-	// the public REST surface. Same lenient rate limit as /health to avoid
-	// throttling the kubelet.
-	router.GET("/livez", middleware.HealthCheckRateLimit(), handler.Livez)
-	router.GET("/readyz", middleware.HealthCheckRateLimit(), handler.Readyz)
+	// the public REST surface. They are deliberately NOT rate limited: the
+	// kubelet probes both endpoints from a single node IP every few seconds,
+	// which blows past any per-IP limit and turns a 429 into a failed readiness
+	// probe that pulls a healthy pod out of rotation.
+	router.GET("/livez", handler.Livez)
+	router.GET("/readyz", handler.Readyz)
 
 	// API routes with rate limiting
 	v1 := router.Group("/api/v1")

--- a/app/internal/domains/message/adapters/primary/api/server_rate_limit_test.go
+++ b/app/internal/domains/message/adapters/primary/api/server_rate_limit_test.go
@@ -186,6 +186,31 @@ func TestServerRateLimiting(t *testing.T) {
 		assert.Equal(t, http.StatusTooManyRequests, w.Code, "301st request should be rate limited")
 	})
 
+	t.Run("kubernetes probes are never rate limited", func(t *testing.T) {
+		// The kubelet probes /livez and /readyz from a single node IP every few
+		// seconds. Rate limiting them turns a healthy pod into a 429, which K8s
+		// reads as a failed readiness probe and pulls the pod from the load
+		// balancer. These infrastructure endpoints must never be throttled.
+		mockService := &MockMessageService{}
+		server := NewServer(mockService, &stubEncryptionPort{}, &stubStoragePort{})
+		router := server.GetRouter()
+
+		// Far more requests than any rate limit window would allow, all from the
+		// same source IP (mimicking the kubelet node).
+		for _, path := range []string{"/livez", "/readyz"} {
+			for i := 0; i < 500; i++ {
+				req := httptest.NewRequest(http.MethodGet, path, nil)
+				req.Header.Set("X-Forwarded-For", "10.88.1.130")
+				w := httptest.NewRecorder()
+
+				router.ServeHTTP(w, req)
+				require.NotEqual(t, http.StatusTooManyRequests, w.Code,
+					"%s request %d must not be rate limited", path, i+1)
+				assert.Equal(t, http.StatusOK, w.Code, "%s request %d should return 200", path, i+1)
+			}
+		}
+	})
+
 	t.Run("different IPs have separate rate limits", func(t *testing.T) {
 		mockService := &MockMessageService{}
 		server := NewServer(mockService, &stubEncryptionPort{}, &stubStoragePort{})

--- a/app/internal/domains/message/adapters/primary/web/server.go
+++ b/app/internal/domains/message/adapters/primary/web/server.go
@@ -110,9 +110,13 @@ func (s *WebServer) setupAPIRoutes() {
 	// Process-alive and dependency-aware probes live on the root, not under
 	// /api/v1 — k8s probe paths shouldn't be versioned alongside the public
 	// REST surface. They're attached to s.router (not the apiGroup) so they
-	// stay reachable at the documented /livez and /readyz paths.
-	s.router.GET("/livez", middleware.HealthCheckRateLimit(), apiHandler.Livez)
-	s.router.GET("/readyz", middleware.HealthCheckRateLimit(), apiHandler.Readyz)
+	// stay reachable at the documented /livez and /readyz paths. They are
+	// deliberately NOT rate limited: the kubelet probes both endpoints from a
+	// single node IP every few seconds, which blows past any per-IP limit and
+	// turns a 429 into a failed readiness probe that pulls a healthy pod out of
+	// rotation.
+	s.router.GET("/livez", apiHandler.Livez)
+	s.router.GET("/readyz", apiHandler.Readyz)
 
 	// Add API middleware
 	apiGroup := s.router.Group("/api")


### PR DESCRIPTION
The kubelet probes /livez and /readyz from a single node IP every few seconds. The HealthCheckRateLimit cap of 300 req/hour (1 per 12s) is exceeded by the readiness probe interval, returning 429s. Kubernetes reads a 429 on /readyz as a failed readiness probe and pulls a healthy pod out of the load balancer.

Liveness/readiness probes are trusted infrastructure traffic and must never be throttled, so remove the rate limit middleware from both the api and web server probe routes.