### PR TITLE
fix(ux): combine E2E key and file params into one share URL fragment

### DIFF
--- a/app/templates/assets/js/file-upload.js
+++ b/app/templates/assets/js/file-upload.js
@@ -243,22 +243,10 @@ function buildFileShareURL(fileID, encodedKey, origin) {
 }
 
 /**
- * buildCombinedShareURL appends file params to a message share URL so the
- * recipient can download the attached file from the same link.
- *
- * @param {string} messageWebUrl  The message share URL (e.g. result.webUrl)
- * @param {string} fileID
- * @param {string} encodedKey
- */
-function buildCombinedShareURL(messageWebUrl, fileID, encodedKey) {
-    const u = new URL(messageWebUrl, window.location.origin);
-    u.hash = 'fid=' + encodeURIComponent(fileID) + '&fk=' + encodedKey;
-    return u.toString();
-}
-
-/**
  * extractCombinedFileParams reads the fid/fk params embedded in the current
- * page's URL fragment by buildCombinedShareURL.
+ * page's URL fragment by the message submission flow. The fragment may also
+ * carry an E2E `key` param; both share a single fragment (…#key=…&fid=…&fk=…)
+ * because a URL can only have one fragment.
  *
  * Returns { fileID, encodedKey } or null if either value is absent.
  */

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -961,12 +961,23 @@ document.addEventListener('DOMContentLoaded', function() {
                     }
                 }
 
-                const shareURL = uploadResult
-                    ? buildCombinedShareURL(result.webUrl, uploadResult.fileID, uploadResult.encodedKey)
+                // A URL can carry only ONE #fragment, so the E2E key and the file
+                // download params must share it. Building them as separate fragments
+                // (…#key=… plus …#fid=…&fk=…) produces a double-hash URL where neither
+                // the message key nor the file is recoverable. Both values are read back
+                // on the decryption page via URLSearchParams (getFragmentKey +
+                // extractCombinedFileParams), so a single &-joined fragment works for both.
+                const fragmentParts = [];
+                if (result.isClientEncrypted && e2eKey) {
+                    fragmentParts.push(`key=${encodeURIComponent(e2eKey)}`);
+                }
+                if (uploadResult) {
+                    fragmentParts.push(`fid=${encodeURIComponent(uploadResult.fileID)}`);
+                    fragmentParts.push(`fk=${uploadResult.encodedKey}`);
+                }
+                const finalShareURL = fragmentParts.length
+                    ? `${result.webUrl}#${fragmentParts.join('&')}`
                     : result.webUrl;
-                const finalShareURL = (result.isClientEncrypted && e2eKey)
-                    ? `${shareURL}#key=${encodeURIComponent(e2eKey)}`
-                    : shareURL;
 
                 // Success - show the secure link
                 const successDiv = document.getElementById('success');


### PR DESCRIPTION
When a message used client-side E2E encryption AND had a file attachment, the share URL was built with two separate fragments — the file params via buildCombinedShareURL (#fid=...&fk=...) and then the E2E key appended as #key=.... A URL can only have one fragment, so the result was a double-hash URL (...#fid=...&fk=...#key=...) where neither the message key nor the file key could be recovered by the recipient's parsers, making both unfindable.

Build a single &-joined fragment containing key, fid and fk. Both are read back independently via URLSearchParams on the decryption page, so order is irrelevant and every combination (E2E/server-side, with/without file) now resolves correctly. Remove the now-unused buildCombinedShareURL helper.