### PR TITLE
fix(e2e): include key fragment in email notification link for E2E messages

### DIFF
--- a/app/internal/domains/message/adapters/primary/api/handlers.go
+++ b/app/internal/domains/message/adapters/primary/api/handlers.go
@@ -99,6 +99,7 @@ func (h *MessageAPIHandler) SubmitMessage(c *gin.Context) {
 	domainReq := domain.MessageSubmissionRequest{
 		Content:           req.Content,
 		IsClientEncrypted: req.IsClientEncrypted,
+		E2EKey:            req.E2EKey,
 		Passphrase:        req.Passphrase,
 		AdditionalInfo:    req.AdditionalInfo,
 		Captcha:           req.AntiSpamAnswer,

--- a/app/internal/domains/message/adapters/primary/api/models/message.go
+++ b/app/internal/domains/message/adapters/primary/api/models/message.go
@@ -6,17 +6,21 @@ import (
 
 // MessageSubmissionRequest represents a REST API request to submit a new message
 type MessageSubmissionRequest struct {
-	Content           string     `json:"content"                  validate:"required,min=1"`
-	IsClientEncrypted bool       `json:"isClientEncrypted,omitempty"`
-	Sender            *Sender    `json:"sender,omitempty"`
-	Recipient         *Recipient `json:"recipient,omitempty"`
-	Passphrase        string     `json:"passphrase,omitempty"     validate:"max=500"`
-	AdditionalInfo    string     `json:"additionalInfo,omitempty"`
-	SendNotification  bool       `json:"sendNotification"`
-	AntiSpamAnswer    string     `json:"antiSpamAnswer,omitempty"`
-	QuestionID        *int       `json:"questionId,omitempty"`
-	MaxViewCount      int        `json:"maxViewCount,omitempty"   validate:"min=0,max=100"`
-	TurnstileToken    string     `json:"turnstileToken,omitempty" validate:"max=2048"`
+	Content           string `json:"content"                  validate:"required,min=1"`
+	IsClientEncrypted bool   `json:"isClientEncrypted,omitempty"`
+	// E2EKey is the base64url-encoded client-generated AES key for E2E encrypted messages.
+	// Required when isClientEncrypted is true and sendNotification is true so the
+	// email link includes the #key fragment. Not stored server-side.
+	E2EKey           string     `json:"e2eKey,omitempty"         validate:"max=512"`
+	Sender           *Sender    `json:"sender,omitempty"`
+	Recipient        *Recipient `json:"recipient,omitempty"`
+	Passphrase       string     `json:"passphrase,omitempty"     validate:"max=500"`
+	AdditionalInfo   string     `json:"additionalInfo,omitempty"`
+	SendNotification bool       `json:"sendNotification"`
+	AntiSpamAnswer   string     `json:"antiSpamAnswer,omitempty"`
+	QuestionID       *int       `json:"questionId,omitempty"`
+	MaxViewCount     int        `json:"maxViewCount,omitempty"   validate:"min=0,max=100"`
+	TurnstileToken   string     `json:"turnstileToken,omitempty" validate:"max=2048"`
 	// ExpirationHours specifies a custom expiration in hours. When 0 or omitted, the server default (7 days / 168 hours) applies.
 	// Valid range: 1–2160 (1 hour to 90 days).
 	ExpirationHours int `json:"expirationHours,omitempty" validate:"min=0,max=2160"`

--- a/app/internal/domains/message/adapters/secondary/url/builder.go
+++ b/app/internal/domains/message/adapters/secondary/url/builder.go
@@ -29,8 +29,13 @@ func (u *URLBuilder) BuildDecryptURL(messageID string, encryptionKey []byte) str
 }
 
 // BuildE2EDecryptURL builds a URL for client-side end-to-end decryption.
-func (u *URLBuilder) BuildE2EDecryptURL(messageID string) string {
+// When e2eKeyBase64Url is non-empty it is appended as #key=<e2eKeyBase64Url>
+// so that email recipients receive a complete, self-contained link.
+func (u *URLBuilder) BuildE2EDecryptURL(messageID string, e2eKeyBase64Url string) string {
 	decryptURL := fmt.Sprintf("%sdecrypt/%s", u.baseURL, messageID)
+	if e2eKeyBase64Url != "" {
+		decryptURL = fmt.Sprintf("%s#key=%s", decryptURL, e2eKeyBase64Url)
+	}
 	logging.Debug().Str("messageId", messageID).Str("url", decryptURL).Msg("Built E2E decrypt URL")
 	return decryptURL
 }

--- a/app/internal/domains/message/domain/message_service.go
+++ b/app/internal/domains/message/domain/message_service.go
@@ -116,7 +116,7 @@ func (s *MessageService) SubmitMessage(
 	}
 
 	// Build the decryption URL
-	decryptURL := s.buildDecryptURL(messageID, req.IsClientEncrypted, encryptionKey)
+	decryptURL := s.buildDecryptURL(messageID, req.IsClientEncrypted, encryptionKey, req.E2EKey)
 
 	// Determine max view count (use request value or default from config)
 	maxViewCount := req.MaxViewCount
@@ -315,9 +315,9 @@ func (s *MessageService) prepareStoredContent(
 	return strings.Join(encryptedContent, ""), encryptionKey, nil
 }
 
-func (s *MessageService) buildDecryptURL(messageID string, isClientEncrypted bool, encryptionKey []byte) string {
+func (s *MessageService) buildDecryptURL(messageID string, isClientEncrypted bool, encryptionKey []byte, e2eKey string) string {
 	if isClientEncrypted {
-		return s.urlBuilder.BuildE2EDecryptURL(messageID)
+		return s.urlBuilder.BuildE2EDecryptURL(messageID, e2eKey)
 	}
 	return s.urlBuilder.BuildDecryptURL(messageID, encryptionKey)
 }

--- a/app/internal/domains/message/domain/message_service_test.go
+++ b/app/internal/domains/message/domain/message_service_test.go
@@ -113,8 +113,8 @@ func (m *mockURLBuilder) BuildDecryptURL(messageID string, encryptionKey []byte)
 	return args.String(0)
 }
 
-func (m *mockURLBuilder) BuildE2EDecryptURL(messageID string) string {
-	args := m.Called(messageID)
+func (m *mockURLBuilder) BuildE2EDecryptURL(messageID string, e2eKeyBase64Url string) string {
+	args := m.Called(messageID, e2eKeyBase64Url)
 	return args.String(0)
 }
 
@@ -535,12 +535,12 @@ func TestSubmitMessage_ClientEncrypted_UsesE2EURLAndSkipsServerEncryption(t *tes
 		return storeReq.IsClientEncrypted && storeReq.Content == "client-side-ciphertext"
 	})).Return(nil)
 
-	urlb.On("BuildE2EDecryptURL", "msg-client-e2e").Return("https://example.com/decrypt/msg-client-e2e").Maybe()
+	urlb.On("BuildE2EDecryptURL", "msg-client-e2e", "").Return("https://example.com/decrypt/msg-client-e2e").Maybe()
 
 	resp, err := svc.SubmitMessage(context.Background(), req)
 	assert.NoError(t, err)
 	assert.Equal(t, "", resp.Key, "key must be empty for client-side encrypted messages")
-	urlb.AssertCalled(t, "BuildE2EDecryptURL", "msg-client-e2e")
+	urlb.AssertCalled(t, "BuildE2EDecryptURL", "msg-client-e2e", "")
 	urlb.AssertNotCalled(t, "BuildDecryptURL", "msg-client-e2e", mock.Anything)
 	enc.AssertNotCalled(t, "GenerateKey", mock.Anything, int32(32))
 	enc.AssertNotCalled(t, "Encrypt", mock.Anything, []string{"client-side-ciphertext"}, mock.Anything)

--- a/app/internal/domains/message/ports/contracts/types.go
+++ b/app/internal/domains/message/ports/contracts/types.go
@@ -19,17 +19,21 @@ type LogEvent = logport.LogEvent
 type MessageSubmissionRequest struct {
 	Content           string
 	IsClientEncrypted bool
-	SenderName        string
-	SenderEmail       string
-	RecipientName     string
-	RecipientEmail    string
-	Passphrase        string
-	AdditionalInfo    string
-	Captcha           string
-	TurnstileToken    string
-	SendNotification  bool
-	MaxViewCount      int
-	ExpirationHours   int
+	// E2EKey is the base64url-encoded client-generated AES key for E2E encrypted messages.
+	// When non-empty it is embedded in the email notification URL as #key=<E2EKey> so
+	// that recipients receive a complete, self-contained link. The key is not stored.
+	E2EKey           string
+	SenderName       string
+	SenderEmail      string
+	RecipientName    string
+	RecipientEmail   string
+	Passphrase       string
+	AdditionalInfo   string
+	Captcha          string
+	TurnstileToken   string
+	SendNotification bool
+	MaxViewCount     int
+	ExpirationHours  int
 }
 
 // MessageSubmissionResponse represents the response to a message submission

--- a/app/internal/domains/message/ports/secondary/url.go
+++ b/app/internal/domains/message/ports/secondary/url.go
@@ -20,5 +20,8 @@ type URLBuilderPort interface {
 	// Example:
 	//   https://example.com/decrypt/abc123#key=base64encodedkey
 	BuildDecryptURL(messageID string, encryptionKey []byte) string
-	BuildE2EDecryptURL(messageID string) string
+	// BuildE2EDecryptURL constructs the URL for a client-side encrypted message.
+	// When e2eKeyBase64Url is non-empty the key is appended as a URL fragment
+	// (#key=<e2eKeyBase64Url>) so that email recipients can decrypt the message.
+	BuildE2EDecryptURL(messageID string, e2eKeyBase64Url string) string
 }

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -933,6 +933,10 @@ document.addEventListener('DOMContentLoaded', function() {
                 };
                 payload.antiSpamAnswer = document.getElementById('color').value.trim();
                 payload.questionId = parseInt(document.getElementById('question-id').value);
+                // Include the E2E key so the server can embed it in the email link fragment.
+                if (e2eKey) {
+                    payload.e2eKey = e2eKey;
+                }
             }
             
             // Make API call


### PR DESCRIPTION
## Summary

- Email links for E2E encrypted messages were missing the `#key=<base64url-key>` fragment, so recipients could not decrypt them
- The client-generated E2E key is now sent in the submission payload (`e2eKey` field) when email notification is enabled
- `BuildE2EDecryptURL` embeds the key as a URL fragment — the key is not stored server-side

## Test plan

- [ ] Submit an E2E encrypted message with email notification enabled and confirm the email link contains `#key=...`
- [ ] Verify the recipient can open the email link and successfully decrypt the message
- [ ] Submit an E2E encrypted message **without** email notification and confirm behaviour is unchanged
- [ ] Submit a non-E2E message with email notification and confirm the existing URL format is unchanged
- [ ] Run `go test ./internal/domains/message/...` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)