### PR TITLE
docs(api): add field-level required/optional descriptions to all models

### DIFF
--- a/app/docs/docs.go
+++ b/app/docs/docs.go
@@ -496,22 +496,27 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "exists": {
+                    "description": "True if the message exists and has not yet been consumed.",
                     "type": "boolean"
                 },
                 "expiresAt": {
-                    "description": "ExpiresAt is the time the message will expire. Null for legacy messages that predate expiry tracking.",
+                    "description": "Time at which the message will be automatically deleted. Null for legacy messages.",
                     "type": "string"
                 },
                 "hasBeenAccessed": {
+                    "description": "True if the message has already been viewed at least once.",
                     "type": "boolean"
                 },
                 "isClientEncrypted": {
+                    "description": "True when the stored content is client-side encrypted (E2E mode); decryption happens in the browser.",
                     "type": "boolean"
                 },
                 "messageId": {
+                    "description": "Unique ID of the message.",
                     "type": "string"
                 },
                 "requiresPassphrase": {
+                    "description": "True if the message requires a passphrase before it can be decrypted.",
                     "type": "boolean"
                 }
             }
@@ -520,10 +525,12 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "decryptionKey": {
+                    "description": "Optional. Base64url-encoded decryption key. Omit for client-encrypted (E2E) messages\nwhere decryption happens client-side. Max 4096 characters.",
                     "type": "string",
                     "maxLength": 4096
                 },
                 "passphrase": {
+                    "description": "Optional. Passphrase required if the message was created with one.",
                     "type": "string"
                 }
             }
@@ -532,25 +539,31 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "content": {
+                    "description": "Decrypted message content. For E2E messages this is the raw ciphertext; the client decrypts it.",
                     "type": "string"
                 },
                 "decryptedAt": {
+                    "description": "Timestamp of this decryption.",
                     "type": "string"
                 },
                 "expiresAt": {
-                    "description": "ExpiresAt is the time the message will expire. Null for legacy messages that predate expiry tracking.",
+                    "description": "Time at which the message will be automatically deleted. Null for legacy messages.",
                     "type": "string"
                 },
                 "isClientEncrypted": {
+                    "description": "True when the content is client-side encrypted (E2E mode).",
                     "type": "boolean"
                 },
                 "maxViewCount": {
+                    "description": "Maximum allowed views before deletion. 0 means unlimited.",
                     "type": "integer"
                 },
                 "messageId": {
+                    "description": "Unique ID of the message.",
                     "type": "string"
                 },
                 "viewCount": {
+                    "description": "Number of times this message has been viewed.",
                     "type": "integer"
                 }
             }
@@ -562,46 +575,70 @@ const docTemplate = `{
             ],
             "properties": {
                 "additionalInfo": {
+                    "description": "Optional. Free-form text included in the notification email body.",
                     "type": "string"
                 },
                 "antiSpamAnswer": {
+                    "description": "Optional. Answer to the anti-spam question identified by questionId.\nRequired when sendNotification is true.",
                     "type": "string"
                 },
                 "content": {
+                    "description": "Required. The message content to encrypt and store. 1–10000 characters.",
                     "type": "string",
                     "minLength": 1
                 },
+                "e2eKey": {
+                    "description": "Optional. Base64url-encoded client-generated AES key for E2E encrypted messages.\nRequired when isClientEncrypted is true and sendNotification is true so the\nemail link includes the #key fragment. Not stored server-side. Max 512 characters.",
+                    "type": "string",
+                    "maxLength": 512
+                },
                 "expirationHours": {
-                    "description": "ExpirationHours specifies a custom expiration in hours. When 0 or omitted, the server default (7 days / 168 hours) applies.\nValid range: 1–2160 (1 hour to 90 days).",
+                    "description": "Optional. Custom expiration in hours. When 0 or omitted the server default (168 h / 7 days) applies.\nValid range: 1–2160 (1 hour to 90 days).",
                     "type": "integer",
                     "maximum": 2160,
                     "minimum": 0
                 },
                 "isClientEncrypted": {
+                    "description": "Optional. Set to true if the content is already client-side encrypted (E2E mode).\nWhen true, the server stores the ciphertext as-is without re-encrypting.",
                     "type": "boolean"
                 },
                 "maxViewCount": {
+                    "description": "Optional. Maximum number of times the message may be viewed before it is deleted. 0 means unlimited.",
                     "type": "integer",
                     "maximum": 100,
                     "minimum": 0
                 },
                 "passphrase": {
+                    "description": "Optional. Passphrase that the recipient must supply before decrypting. Max 500 characters.",
                     "type": "string",
                     "maxLength": 500
                 },
                 "questionId": {
+                    "description": "Optional. ID of the anti-spam question the user answered.\nRequired when sendNotification is true.",
                     "type": "integer"
                 },
                 "recipient": {
-                    "$ref": "#/definitions/models.Recipient"
+                    "description": "Optional. Recipient details. Required when sendNotification is true.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.Recipient"
+                        }
+                    ]
                 },
                 "sendNotification": {
+                    "description": "Optional. Set to true to send an email notification to the recipient.\nRequires sender and recipient to be set.",
                     "type": "boolean"
                 },
                 "sender": {
-                    "$ref": "#/definitions/models.Sender"
+                    "description": "Optional. Sender details. Required when sendNotification is true.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.Sender"
+                        }
+                    ]
                 },
                 "turnstileToken": {
+                    "description": "Optional. Cloudflare Turnstile token for bot protection. Max 2048 characters.",
                     "type": "string",
                     "maxLength": 2048
                 }
@@ -611,25 +648,31 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "decryptUrl": {
+                    "description": "Full URL the recipient should visit to decrypt the message.",
                     "type": "string"
                 },
                 "expiresAt": {
-                    "description": "ExpiresAt is the time the message will expire. Null for legacy messages that predate expiry tracking.",
+                    "description": "Time at which the message will be automatically deleted. Null for legacy messages.",
                     "type": "string"
                 },
                 "isClientEncrypted": {
+                    "description": "True when the stored content is client-side encrypted (E2E mode).",
                     "type": "boolean"
                 },
                 "key": {
+                    "description": "Base64url-encoded decryption key. Include this in the share URL fragment so it never reaches the server.",
                     "type": "string"
                 },
                 "messageId": {
+                    "description": "Unique ID of the created message.",
                     "type": "string"
                 },
                 "notificationSent": {
+                    "description": "True if an email notification was successfully sent to the recipient.",
                     "type": "boolean"
                 },
                 "webUrl": {
+                    "description": "Web UI URL for the message (without the key fragment).",
                     "type": "string"
                 }
             }
@@ -641,9 +684,11 @@ const docTemplate = `{
             ],
             "properties": {
                 "email": {
+                    "description": "Required. Recipient's email address.",
                     "type": "string"
                 },
                 "name": {
+                    "description": "Optional. Recipient's display name. 1–100 characters.",
                     "type": "string",
                     "maxLength": 100,
                     "minLength": 1
@@ -658,9 +703,11 @@ const docTemplate = `{
             ],
             "properties": {
                 "email": {
+                    "description": "Required. Sender's email address.",
                     "type": "string"
                 },
                 "name": {
+                    "description": "Required. Sender's display name. 1–100 characters.",
                     "type": "string",
                     "maxLength": 100,
                     "minLength": 1

--- a/app/docs/swagger.json
+++ b/app/docs/swagger.json
@@ -494,22 +494,27 @@
             "type": "object",
             "properties": {
                 "exists": {
+                    "description": "True if the message exists and has not yet been consumed.",
                     "type": "boolean"
                 },
                 "expiresAt": {
-                    "description": "ExpiresAt is the time the message will expire. Null for legacy messages that predate expiry tracking.",
+                    "description": "Time at which the message will be automatically deleted. Null for legacy messages.",
                     "type": "string"
                 },
                 "hasBeenAccessed": {
+                    "description": "True if the message has already been viewed at least once.",
                     "type": "boolean"
                 },
                 "isClientEncrypted": {
+                    "description": "True when the stored content is client-side encrypted (E2E mode); decryption happens in the browser.",
                     "type": "boolean"
                 },
                 "messageId": {
+                    "description": "Unique ID of the message.",
                     "type": "string"
                 },
                 "requiresPassphrase": {
+                    "description": "True if the message requires a passphrase before it can be decrypted.",
                     "type": "boolean"
                 }
             }
@@ -518,10 +523,12 @@
             "type": "object",
             "properties": {
                 "decryptionKey": {
+                    "description": "Optional. Base64url-encoded decryption key. Omit for client-encrypted (E2E) messages\nwhere decryption happens client-side. Max 4096 characters.",
                     "type": "string",
                     "maxLength": 4096
                 },
                 "passphrase": {
+                    "description": "Optional. Passphrase required if the message was created with one.",
                     "type": "string"
                 }
             }
@@ -530,25 +537,31 @@
             "type": "object",
             "properties": {
                 "content": {
+                    "description": "Decrypted message content. For E2E messages this is the raw ciphertext; the client decrypts it.",
                     "type": "string"
                 },
                 "decryptedAt": {
+                    "description": "Timestamp of this decryption.",
                     "type": "string"
                 },
                 "expiresAt": {
-                    "description": "ExpiresAt is the time the message will expire. Null for legacy messages that predate expiry tracking.",
+                    "description": "Time at which the message will be automatically deleted. Null for legacy messages.",
                     "type": "string"
                 },
                 "isClientEncrypted": {
+                    "description": "True when the content is client-side encrypted (E2E mode).",
                     "type": "boolean"
                 },
                 "maxViewCount": {
+                    "description": "Maximum allowed views before deletion. 0 means unlimited.",
                     "type": "integer"
                 },
                 "messageId": {
+                    "description": "Unique ID of the message.",
                     "type": "string"
                 },
                 "viewCount": {
+                    "description": "Number of times this message has been viewed.",
                     "type": "integer"
                 }
             }
@@ -560,46 +573,70 @@
             ],
             "properties": {
                 "additionalInfo": {
+                    "description": "Optional. Free-form text included in the notification email body.",
                     "type": "string"
                 },
                 "antiSpamAnswer": {
+                    "description": "Optional. Answer to the anti-spam question identified by questionId.\nRequired when sendNotification is true.",
                     "type": "string"
                 },
                 "content": {
+                    "description": "Required. The message content to encrypt and store. 1–10000 characters.",
                     "type": "string",
                     "minLength": 1
                 },
+                "e2eKey": {
+                    "description": "Optional. Base64url-encoded client-generated AES key for E2E encrypted messages.\nRequired when isClientEncrypted is true and sendNotification is true so the\nemail link includes the #key fragment. Not stored server-side. Max 512 characters.",
+                    "type": "string",
+                    "maxLength": 512
+                },
                 "expirationHours": {
-                    "description": "ExpirationHours specifies a custom expiration in hours. When 0 or omitted, the server default (7 days / 168 hours) applies.\nValid range: 1–2160 (1 hour to 90 days).",
+                    "description": "Optional. Custom expiration in hours. When 0 or omitted the server default (168 h / 7 days) applies.\nValid range: 1–2160 (1 hour to 90 days).",
                     "type": "integer",
                     "maximum": 2160,
                     "minimum": 0
                 },
                 "isClientEncrypted": {
+                    "description": "Optional. Set to true if the content is already client-side encrypted (E2E mode).\nWhen true, the server stores the ciphertext as-is without re-encrypting.",
                     "type": "boolean"
                 },
                 "maxViewCount": {
+                    "description": "Optional. Maximum number of times the message may be viewed before it is deleted. 0 means unlimited.",
                     "type": "integer",
                     "maximum": 100,
                     "minimum": 0
                 },
                 "passphrase": {
+                    "description": "Optional. Passphrase that the recipient must supply before decrypting. Max 500 characters.",
                     "type": "string",
                     "maxLength": 500
                 },
                 "questionId": {
+                    "description": "Optional. ID of the anti-spam question the user answered.\nRequired when sendNotification is true.",
                     "type": "integer"
                 },
                 "recipient": {
-                    "$ref": "#/definitions/models.Recipient"
+                    "description": "Optional. Recipient details. Required when sendNotification is true.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.Recipient"
+                        }
+                    ]
                 },
                 "sendNotification": {
+                    "description": "Optional. Set to true to send an email notification to the recipient.\nRequires sender and recipient to be set.",
                     "type": "boolean"
                 },
                 "sender": {
-                    "$ref": "#/definitions/models.Sender"
+                    "description": "Optional. Sender details. Required when sendNotification is true.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.Sender"
+                        }
+                    ]
                 },
                 "turnstileToken": {
+                    "description": "Optional. Cloudflare Turnstile token for bot protection. Max 2048 characters.",
                     "type": "string",
                     "maxLength": 2048
                 }
@@ -609,25 +646,31 @@
             "type": "object",
             "properties": {
                 "decryptUrl": {
+                    "description": "Full URL the recipient should visit to decrypt the message.",
                     "type": "string"
                 },
                 "expiresAt": {
-                    "description": "ExpiresAt is the time the message will expire. Null for legacy messages that predate expiry tracking.",
+                    "description": "Time at which the message will be automatically deleted. Null for legacy messages.",
                     "type": "string"
                 },
                 "isClientEncrypted": {
+                    "description": "True when the stored content is client-side encrypted (E2E mode).",
                     "type": "boolean"
                 },
                 "key": {
+                    "description": "Base64url-encoded decryption key. Include this in the share URL fragment so it never reaches the server.",
                     "type": "string"
                 },
                 "messageId": {
+                    "description": "Unique ID of the created message.",
                     "type": "string"
                 },
                 "notificationSent": {
+                    "description": "True if an email notification was successfully sent to the recipient.",
                     "type": "boolean"
                 },
                 "webUrl": {
+                    "description": "Web UI URL for the message (without the key fragment).",
                     "type": "string"
                 }
             }
@@ -639,9 +682,11 @@
             ],
             "properties": {
                 "email": {
+                    "description": "Required. Recipient's email address.",
                     "type": "string"
                 },
                 "name": {
+                    "description": "Optional. Recipient's display name. 1–100 characters.",
                     "type": "string",
                     "maxLength": 100,
                     "minLength": 1
@@ -656,9 +701,11 @@
             ],
             "properties": {
                 "email": {
+                    "description": "Required. Sender's email address.",
                     "type": "string"
                 },
                 "name": {
+                    "description": "Required. Sender's display name. 1–100 characters.",
                     "type": "string",
                     "maxLength": 100,
                     "minLength": 1

--- a/app/docs/swagger.yaml
+++ b/app/docs/swagger.yaml
@@ -44,81 +44,131 @@ definitions:
   models.MessageAccessInfoResponse:
     properties:
       exists:
+        description: True if the message exists and has not yet been consumed.
         type: boolean
       expiresAt:
-        description: ExpiresAt is the time the message will expire. Null for legacy
-          messages that predate expiry tracking.
+        description: Time at which the message will be automatically deleted. Null
+          for legacy messages.
         type: string
       hasBeenAccessed:
+        description: True if the message has already been viewed at least once.
         type: boolean
       isClientEncrypted:
+        description: True when the stored content is client-side encrypted (E2E mode);
+          decryption happens in the browser.
         type: boolean
       messageId:
+        description: Unique ID of the message.
         type: string
       requiresPassphrase:
+        description: True if the message requires a passphrase before it can be decrypted.
         type: boolean
     type: object
   models.MessageDecryptRequest:
     properties:
       decryptionKey:
+        description: |-
+          Optional. Base64url-encoded decryption key. Omit for client-encrypted (E2E) messages
+          where decryption happens client-side. Max 4096 characters.
         maxLength: 4096
         type: string
       passphrase:
+        description: Optional. Passphrase required if the message was created with
+          one.
         type: string
     type: object
   models.MessageDecryptResponse:
     properties:
       content:
+        description: Decrypted message content. For E2E messages this is the raw ciphertext;
+          the client decrypts it.
         type: string
       decryptedAt:
+        description: Timestamp of this decryption.
         type: string
       expiresAt:
-        description: ExpiresAt is the time the message will expire. Null for legacy
-          messages that predate expiry tracking.
+        description: Time at which the message will be automatically deleted. Null
+          for legacy messages.
         type: string
       isClientEncrypted:
+        description: True when the content is client-side encrypted (E2E mode).
         type: boolean
       maxViewCount:
+        description: Maximum allowed views before deletion. 0 means unlimited.
         type: integer
       messageId:
+        description: Unique ID of the message.
         type: string
       viewCount:
+        description: Number of times this message has been viewed.
         type: integer
     type: object
   models.MessageSubmissionRequest:
     properties:
       additionalInfo:
+        description: Optional. Free-form text included in the notification email body.
         type: string
       antiSpamAnswer:
+        description: |-
+          Optional. Answer to the anti-spam question identified by questionId.
+          Required when sendNotification is true.
         type: string
       content:
+        description: Required. The message content to encrypt and store. 1–10000 characters.
         minLength: 1
+        type: string
+      e2eKey:
+        description: |-
+          Optional. Base64url-encoded client-generated AES key for E2E encrypted messages.
+          Required when isClientEncrypted is true and sendNotification is true so the
+          email link includes the #key fragment. Not stored server-side. Max 512 characters.
+        maxLength: 512
         type: string
       expirationHours:
         description: |-
-          ExpirationHours specifies a custom expiration in hours. When 0 or omitted, the server default (7 days / 168 hours) applies.
+          Optional. Custom expiration in hours. When 0 or omitted the server default (168 h / 7 days) applies.
           Valid range: 1–2160 (1 hour to 90 days).
         maximum: 2160
         minimum: 0
         type: integer
       isClientEncrypted:
+        description: |-
+          Optional. Set to true if the content is already client-side encrypted (E2E mode).
+          When true, the server stores the ciphertext as-is without re-encrypting.
         type: boolean
       maxViewCount:
+        description: Optional. Maximum number of times the message may be viewed before
+          it is deleted. 0 means unlimited.
         maximum: 100
         minimum: 0
         type: integer
       passphrase:
+        description: Optional. Passphrase that the recipient must supply before decrypting.
+          Max 500 characters.
         maxLength: 500
         type: string
       questionId:
+        description: |-
+          Optional. ID of the anti-spam question the user answered.
+          Required when sendNotification is true.
         type: integer
       recipient:
-        $ref: '#/definitions/models.Recipient'
+        allOf:
+        - $ref: '#/definitions/models.Recipient'
+        description: Optional. Recipient details. Required when sendNotification is
+          true.
       sendNotification:
+        description: |-
+          Optional. Set to true to send an email notification to the recipient.
+          Requires sender and recipient to be set.
         type: boolean
       sender:
-        $ref: '#/definitions/models.Sender'
+        allOf:
+        - $ref: '#/definitions/models.Sender'
+        description: Optional. Sender details. Required when sendNotification is true.
       turnstileToken:
+        description: Optional. Cloudflare Turnstile token for bot protection. Max
+          2048 characters.
         maxLength: 2048
         type: string
     required:
@@ -127,27 +177,36 @@ definitions:
   models.MessageSubmissionResponse:
     properties:
       decryptUrl:
+        description: Full URL the recipient should visit to decrypt the message.
         type: string
       expiresAt:
-        description: ExpiresAt is the time the message will expire. Null for legacy
-          messages that predate expiry tracking.
+        description: Time at which the message will be automatically deleted. Null
+          for legacy messages.
         type: string
       isClientEncrypted:
+        description: True when the stored content is client-side encrypted (E2E mode).
         type: boolean
       key:
+        description: Base64url-encoded decryption key. Include this in the share URL
+          fragment so it never reaches the server.
         type: string
       messageId:
+        description: Unique ID of the created message.
         type: string
       notificationSent:
+        description: True if an email notification was successfully sent to the recipient.
         type: boolean
       webUrl:
+        description: Web UI URL for the message (without the key fragment).
         type: string
     type: object
   models.Recipient:
     properties:
       email:
+        description: Required. Recipient's email address.
         type: string
       name:
+        description: Optional. Recipient's display name. 1–100 characters.
         maxLength: 100
         minLength: 1
         type: string
@@ -157,8 +216,10 @@ definitions:
   models.Sender:
     properties:
       email:
+        description: Required. Sender's email address.
         type: string
       name:
+        description: Required. Sender's display name. 1–100 characters.
         maxLength: 100
         minLength: 1
         type: string

--- a/app/internal/domains/message/adapters/primary/api/models/message.go
+++ b/app/internal/domains/message/adapters/primary/api/models/message.go
@@ -6,77 +6,115 @@ import (
 
 // MessageSubmissionRequest represents a REST API request to submit a new message
 type MessageSubmissionRequest struct {
-	Content           string `json:"content"                  validate:"required,min=1"`
-	IsClientEncrypted bool   `json:"isClientEncrypted,omitempty"`
-	// E2EKey is the base64url-encoded client-generated AES key for E2E encrypted messages.
+	// Required. The message content to encrypt and store. 1–10000 characters.
+	Content string `json:"content" validate:"required,min=1"`
+	// Optional. Set to true if the content is already client-side encrypted (E2E mode).
+	// When true, the server stores the ciphertext as-is without re-encrypting.
+	IsClientEncrypted bool `json:"isClientEncrypted,omitempty"`
+	// Optional. Base64url-encoded client-generated AES key for E2E encrypted messages.
 	// Required when isClientEncrypted is true and sendNotification is true so the
-	// email link includes the #key fragment. Not stored server-side.
-	E2EKey           string     `json:"e2eKey,omitempty"         validate:"max=512"`
-	Sender           *Sender    `json:"sender,omitempty"`
-	Recipient        *Recipient `json:"recipient,omitempty"`
-	Passphrase       string     `json:"passphrase,omitempty"     validate:"max=500"`
-	AdditionalInfo   string     `json:"additionalInfo,omitempty"`
-	SendNotification bool       `json:"sendNotification"`
-	AntiSpamAnswer   string     `json:"antiSpamAnswer,omitempty"`
-	QuestionID       *int       `json:"questionId,omitempty"`
-	MaxViewCount     int        `json:"maxViewCount,omitempty"   validate:"min=0,max=100"`
-	TurnstileToken   string     `json:"turnstileToken,omitempty" validate:"max=2048"`
-	// ExpirationHours specifies a custom expiration in hours. When 0 or omitted, the server default (7 days / 168 hours) applies.
+	// email link includes the #key fragment. Not stored server-side. Max 512 characters.
+	E2EKey string `json:"e2eKey,omitempty" validate:"max=512"`
+	// Optional. Sender details. Required when sendNotification is true.
+	Sender *Sender `json:"sender,omitempty"`
+	// Optional. Recipient details. Required when sendNotification is true.
+	Recipient *Recipient `json:"recipient,omitempty"`
+	// Optional. Passphrase that the recipient must supply before decrypting. Max 500 characters.
+	Passphrase string `json:"passphrase,omitempty" validate:"max=500"`
+	// Optional. Free-form text included in the notification email body.
+	AdditionalInfo string `json:"additionalInfo,omitempty"`
+	// Optional. Set to true to send an email notification to the recipient.
+	// Requires sender and recipient to be set.
+	SendNotification bool `json:"sendNotification"`
+	// Optional. Answer to the anti-spam question identified by questionId.
+	// Required when sendNotification is true.
+	AntiSpamAnswer string `json:"antiSpamAnswer,omitempty"`
+	// Optional. ID of the anti-spam question the user answered.
+	// Required when sendNotification is true.
+	QuestionID *int `json:"questionId,omitempty"`
+	// Optional. Maximum number of times the message may be viewed before it is deleted. 0 means unlimited.
+	MaxViewCount int `json:"maxViewCount,omitempty" validate:"min=0,max=100"`
+	// Optional. Cloudflare Turnstile token for bot protection. Max 2048 characters.
+	TurnstileToken string `json:"turnstileToken,omitempty" validate:"max=2048"`
+	// Optional. Custom expiration in hours. When 0 or omitted the server default (168 h / 7 days) applies.
 	// Valid range: 1–2160 (1 hour to 90 days).
 	ExpirationHours int `json:"expirationHours,omitempty" validate:"min=0,max=2160"`
 }
 
 // Sender represents sender information for message submission
 type Sender struct {
-	Name  string `json:"name"  validate:"required,min=1,max=100"`
+	// Required. Sender's display name. 1–100 characters.
+	Name string `json:"name" validate:"required,min=1,max=100"`
+	// Required. Sender's email address.
 	Email string `json:"email" validate:"required,email"`
 }
 
 // Recipient represents recipient information for message submission
 type Recipient struct {
-	Name  string `json:"name"  validate:"min=1,max=100"`
+	// Optional. Recipient's display name. 1–100 characters.
+	Name string `json:"name" validate:"min=1,max=100"`
+	// Required. Recipient's email address.
 	Email string `json:"email" validate:"required,email"`
 }
 
 // MessageSubmissionResponse represents the response to a message submission
 type MessageSubmissionResponse struct {
-	MessageID         string `json:"messageId"`
-	DecryptURL        string `json:"decryptUrl"`
-	Key               string `json:"key"`
-	IsClientEncrypted bool   `json:"isClientEncrypted"`
-	WebURL            string `json:"webUrl"`
-	// ExpiresAt is the time the message will expire. Null for legacy messages that predate expiry tracking.
-	ExpiresAt        *time.Time `json:"expiresAt"`
-	NotificationSent bool       `json:"notificationSent"`
+	// Unique ID of the created message.
+	MessageID string `json:"messageId"`
+	// Full URL the recipient should visit to decrypt the message.
+	DecryptURL string `json:"decryptUrl"`
+	// Base64url-encoded decryption key. Include this in the share URL fragment so it never reaches the server.
+	Key string `json:"key"`
+	// True when the stored content is client-side encrypted (E2E mode).
+	IsClientEncrypted bool `json:"isClientEncrypted"`
+	// Web UI URL for the message (without the key fragment).
+	WebURL string `json:"webUrl"`
+	// Time at which the message will be automatically deleted. Null for legacy messages.
+	ExpiresAt *time.Time `json:"expiresAt"`
+	// True if an email notification was successfully sent to the recipient.
+	NotificationSent bool `json:"notificationSent"`
 }
 
 // MessageAccessInfoResponse represents information about message access requirements
 type MessageAccessInfoResponse struct {
-	MessageID          string `json:"messageId"`
-	Exists             bool   `json:"exists"`
-	RequiresPassphrase bool   `json:"requiresPassphrase"`
-	IsClientEncrypted  bool   `json:"isClientEncrypted"`
-	HasBeenAccessed    bool   `json:"hasBeenAccessed"`
-	// ExpiresAt is the time the message will expire. Null for legacy messages that predate expiry tracking.
+	// Unique ID of the message.
+	MessageID string `json:"messageId"`
+	// True if the message exists and has not yet been consumed.
+	Exists bool `json:"exists"`
+	// True if the message requires a passphrase before it can be decrypted.
+	RequiresPassphrase bool `json:"requiresPassphrase"`
+	// True when the stored content is client-side encrypted (E2E mode); decryption happens in the browser.
+	IsClientEncrypted bool `json:"isClientEncrypted"`
+	// True if the message has already been viewed at least once.
+	HasBeenAccessed bool `json:"hasBeenAccessed"`
+	// Time at which the message will be automatically deleted. Null for legacy messages.
 	ExpiresAt *time.Time `json:"expiresAt"`
 }
 
 // MessageDecryptRequest represents a request to decrypt a message.
-// DecryptionKey is empty for client-encrypted (E2E) messages, where decryption happens client-side.
 type MessageDecryptRequest struct {
+	// Optional. Base64url-encoded decryption key. Omit for client-encrypted (E2E) messages
+	// where decryption happens client-side. Max 4096 characters.
 	DecryptionKey string `json:"decryptionKey,omitempty" validate:"max=4096"`
-	Passphrase    string `json:"passphrase,omitempty"`
+	// Optional. Passphrase required if the message was created with one.
+	Passphrase string `json:"passphrase,omitempty"`
 }
 
 // MessageDecryptResponse represents the response to a message decryption
 type MessageDecryptResponse struct {
-	MessageID         string    `json:"messageId"`
-	Content           string    `json:"content"`
-	IsClientEncrypted bool      `json:"isClientEncrypted"`
-	ViewCount         int       `json:"viewCount"`
-	MaxViewCount      int       `json:"maxViewCount"`
-	DecryptedAt       time.Time `json:"decryptedAt"`
-	// ExpiresAt is the time the message will expire. Null for legacy messages that predate expiry tracking.
+	// Unique ID of the message.
+	MessageID string `json:"messageId"`
+	// Decrypted message content. For E2E messages this is the raw ciphertext; the client decrypts it.
+	Content string `json:"content"`
+	// True when the content is client-side encrypted (E2E mode).
+	IsClientEncrypted bool `json:"isClientEncrypted"`
+	// Number of times this message has been viewed.
+	ViewCount int `json:"viewCount"`
+	// Maximum allowed views before deletion. 0 means unlimited.
+	MaxViewCount int `json:"maxViewCount"`
+	// Timestamp of this decryption.
+	DecryptedAt time.Time `json:"decryptedAt"`
+	// Time at which the message will be automatically deleted. Null for legacy messages.
 	ExpiresAt *time.Time `json:"expiresAt"`
 }
 


### PR DESCRIPTION
Swagger UI 2.0 only shows required indicators in Schema view; the default Example Value view gives no indication. Add explicit "Required." / "Optional." prefixes and usage notes to every field comment so the description appears inline in the Schema tab. Also incorporates the new e2eKey field added in #505.