### PR TITLE
fix(slackbot): correct MessageServiceStub casing in encryptionClient

### DIFF
--- a/slackbot/encryptionClient.py
+++ b/slackbot/encryptionClient.py
@@ -27,7 +27,7 @@ class EncryptionServiceClient(object):
             None.
         """
         self.channel = grpc.insecure_channel(f'{SERVER_ADDRESS}:{PORT}')
-        self.stub = encryption_pb2_grpc.messageServiceStub(self.channel)
+        self.stub = encryption_pb2_grpc.MessageServiceStub(self.channel)
     def generate_random_strng(self, length):
         """Generates a cryptographically random string from the given length
 


### PR DESCRIPTION
## Summary
- `encryption_pb2_grpc.messageServiceStub` → `MessageServiceStub` to match the proto-generated class name
- Pod was crashing on startup with `AttributeError: module 'protos.encryption_pb2_grpc' has no attribute 'messageServiceStub'`

## Test plan
- [ ] Deploy slackbot pod and confirm it starts without `AttributeError`
- [ ] Verify encryption calls succeed via Slack command

🤖 Generated with [Claude Code](https://claude.com/claude-code)