### PR TITLE
fix(e2e): update Playwright Docker image from v1.44.0 to v1.60.0

### DIFF
--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.44.0-jammy
+FROM mcr.microsoft.com/playwright:v1.60.0-jammy
 WORKDIR /e2e
 COPY package*.json ./
 RUN npm ci


### PR DESCRIPTION
## Summary

- Playwright was updated to 1.60.0 but the e2e `Dockerfile` still referenced `v1.44.0-jammy`
- This caused the ArgoCD PostSync e2e hook to fail: chromium executable not found at the expected path
- Updates the base image to `mcr.microsoft.com/playwright:v1.60.0-jammy` to match the installed Playwright version

## Test plan

- [ ] ArgoCD PostSync e2e hook runs without the "Executable doesn't exist" error
- [ ] Playwright tests execute successfully against chromium

🤖 Generated with [Claude Code](https://claude.com/claude-code)