### PR TITLE
feat(e2e): add Firefox Playwright PostSync hook and CI build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,9 +139,37 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  build_e2e_firefox_image:
+    runs-on: ubuntu-24.04
+    needs: [determine_version, test]
+    env:
+      VERSION: ${{ needs.determine_version.outputs.version }}
+      PHASE: ${{ needs.determine_version.outputs.phase }}
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.PUSH_SECRET }}
+      - uses: actions/checkout@v4
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push e2e Firefox Docker image
+        uses: docker/build-push-action@v6
+        env:
+          SOURCE_DATE_EPOCH: 0
+        with:
+          context: ./e2e
+          file: ./e2e/Dockerfile.firefox
+          push: true
+          tags: ghcr.io/anthony-bible/passwordexchange-e2e-firefox-${{ env.PHASE }}:${{ env.VERSION }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   render_and_deploy:
     runs-on: ubuntu-24.04
-    needs: [determine_version, build_main_image, build_slackbot_image, build_e2e_image]
+    needs: [determine_version, build_main_image, build_slackbot_image, build_e2e_image, build_e2e_firefox_image]
     env:
       VERSION: ${{ needs.determine_version.outputs.version }}
       PHASE: ${{ needs.determine_version.outputs.phase }}

--- a/e2e/Dockerfile.firefox
+++ b/e2e/Dockerfile.firefox
@@ -1,0 +1,7 @@
+FROM mcr.microsoft.com/playwright:v1.60.0-jammy
+WORKDIR /e2e
+COPY package*.json ./
+RUN npm ci
+COPY . .
+ENV CI=true
+ENTRYPOINT ["npx", "playwright", "test", "--reporter=line", "--project=firefox"]

--- a/k8s/e2e-tests-firefox.job.yaml
+++ b/k8s/e2e-tests-firefox.job.yaml
@@ -1,0 +1,27 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: e2e-tests-firefox-%{VERSION}
+  namespace: default
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 3600
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: playwright
+          image: ghcr.io/anthony-bible/passwordexchange-e2e-firefox-%{PHASE}:%{VERSION}
+          env:
+            - name: BASE_URL
+              value: "%{BASE_URL}"
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "250m"
+            limits:
+              memory: "2Gi"
+              cpu: "1000m"


### PR DESCRIPTION
## Summary

- Adds `e2e/Dockerfile.firefox` with `--project=firefox` entrypoint (mirrors the existing chromium Dockerfile)
- Adds `k8s/e2e-tests-firefox.job.yaml` ArgoCD PostSync hook Job using image `passwordexchange-e2e-firefox-%{PHASE}:%{VERSION}`
- Adds `build_e2e_firefox_image` CI job that builds and pushes the Firefox image; `render_and_deploy` now depends on it

## Test plan

- [ ] CI `build_e2e_firefox_image` job builds and pushes `ghcr.io/anthony-bible/passwordexchange-e2e-firefox-dev:<sha>` successfully
- [ ] `render_and_deploy` waits for the Firefox image build before proceeding
- [ ] After an ArgoCD sync, the `e2e-tests-firefox-<version>` Job runs and Playwright reports pass against the deployed environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)