### PR TITLE
fix(e2e): use ID locators for fields with tooltip buttons in labels

### DIFF
--- a/e2e/tests/passphrase.spec.ts
+++ b/e2e/tests/passphrase.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 async function createMessage(page: any, secret: string, passphrase?: string): Promise<string> {
   await page.goto('/');
   if (passphrase !== undefined) {
-    await page.getByRole('textbox', { name: 'Passphrase (Optional)' }).fill(passphrase);
+    await page.locator('#other_lastname').fill(passphrase);
   }
   await page.getByRole('textbox', { name: 'Password or Secret Message *' }).fill(secret);
   await page.getByRole('button', { name: ' Create Secure Link' }).click();

--- a/e2e/tests/submit-form.spec.ts
+++ b/e2e/tests/submit-form.spec.ts
@@ -39,16 +39,16 @@ test.describe('Submit secure password form', () => {
   test('shows optional security fields on load', async ({ page }) => {
     await page.goto('/');
 
-    await expect(page.getByRole('textbox', { name: 'Passphrase (Optional)' })).toBeVisible();
-    await expect(page.getByRole('spinbutton', { name: 'Max View Count (Optional)' })).toBeVisible();
-    await expect(page.getByRole('spinbutton', { name: 'Expiration (Optional)' })).toBeVisible();
+    await expect(page.locator('#other_lastname')).toBeVisible();
+    await expect(page.locator('#max_view_count')).toBeVisible();
+    await expect(page.locator('#expiration_value')).toBeVisible();
   });
 
   test('submits form with passphrase and custom view count', async ({ page }) => {
     await page.goto('/');
 
-    await page.getByRole('textbox', { name: 'Passphrase (Optional)' }).fill('mypassphrase');
-    await page.getByRole('spinbutton', { name: 'Max View Count (Optional)' }).fill('3');
+    await page.locator('#other_lastname').fill('mypassphrase');
+    await page.locator('#max_view_count').fill('3');
     await page.getByRole('textbox', { name: 'Password or Secret Message *' }).fill('SecretWithOptions!');
 
     await page.getByRole('button', { name: ' Create Secure Link' }).click();

--- a/e2e/tests/view-count.spec.ts
+++ b/e2e/tests/view-count.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 async function createMessage(page: any, secret: string, maxViewCount?: number): Promise<string> {
   await page.goto('/');
   if (maxViewCount !== undefined) {
-    await page.getByRole('spinbutton', { name: 'Max View Count (Optional)' }).fill(String(maxViewCount));
+    await page.locator('#max_view_count').fill(String(maxViewCount));
   }
   await page.getByRole('textbox', { name: 'Password or Secret Message *' }).fill(secret);
   await page.getByRole('button', { name: ' Create Secure Link' }).click();


### PR DESCRIPTION
## Summary

- Fixes test timeouts caused by `getByRole` failing to match accessible names on three form fields
- Swaps to stable `#id` selectors in `passphrase.spec.ts`, `submit-form.spec.ts`, and `view-count.spec.ts`

## Root cause

In Playwright 1.27+, `getByRole` does **exact** accessible name matching by default. The passphrase, max view count, and expiration fields each have a tooltip `<button aria-label="...">` nested inside their `<label>`. The browser folds that button's `aria-label` into the input's computed accessible name:

| Field | Actual accessible name |
|---|---|
| Passphrase | `"Passphrase (Optional) Help about passphrase"` |
| Max View Count | `"Max View Count (Optional) Help about max view count"` |
| Expiration | `"Expiration (Optional) Help about expiration"` |

The tests were matching on the shorter prefix only → no match → 30s timeout on every retry.

## Fix

Use `#other_lastname`, `#max_view_count`, and `#expiration_value` ID selectors — immune to accessible name computation.

## Test plan

- [ ] Passphrase tests no longer time out in the PostSync hook job
- [ ] `shows optional security fields on load` and `submits form with passphrase and custom view count` pass
- [ ] View-count tests with custom `maxViewCount` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)