### PR TITLE
feat(e2e): add Cloudflare bypass header support

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
     launchOptions: {
       slowMo: parseInt(process.env.SLOWMO || '0'),
     },
+    ...(process.env.E2E_BYPASS_HEADER_NAME && process.env.E2E_BYPASS_HEADER_VALUE
+      ? { extraHTTPHeaders: { [process.env.E2E_BYPASS_HEADER_NAME]: process.env.E2E_BYPASS_HEADER_VALUE } }
+      : {}),
   },
   projects: [
     {

--- a/k8s/e2e-tests-firefox.job.yaml
+++ b/k8s/e2e-tests-firefox.job.yaml
@@ -18,6 +18,16 @@ spec:
           env:
             - name: BASE_URL
               value: "%{BASE_URL}"
+            - name: E2E_BYPASS_HEADER_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: test-secret
+                  key: E2E_BYPASS_HEADER_NAME
+            - name: E2E_BYPASS_HEADER_VALUE
+              valueFrom:
+                secretKeyRef:
+                  name: test-secret
+                  key: E2E_BYPASS_HEADER_VALUE
           resources:
             requests:
               memory: "512Mi"

--- a/k8s/e2e-tests.job.yaml
+++ b/k8s/e2e-tests.job.yaml
@@ -18,6 +18,16 @@ spec:
           env:
             - name: BASE_URL
               value: "%{BASE_URL}"
+            - name: E2E_BYPASS_HEADER_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: test-secret
+                  key: E2E_BYPASS_HEADER_NAME
+            - name: E2E_BYPASS_HEADER_VALUE
+              valueFrom:
+                secretKeyRef:
+                  name: test-secret
+                  key: E2E_BYPASS_HEADER_VALUE
           resources:
             requests:
               memory: "512Mi"


### PR DESCRIPTION
## Summary

- Adds `extraHTTPHeaders` to Playwright config, populated from `E2E_BYPASS_HEADER_NAME` / `E2E_BYPASS_HEADER_VALUE` env vars — no-ops when vars are absent so local runs are unaffected
- Both `e2e-tests.job.yaml` and `e2e-tests-firefox.job.yaml` pull those vars from the `test-secret` k8s secret

## Why

Firefox e2e tests were failing/flaky because Cloudflare was serving challenge pages instead of the app. A WAF rule keyed on a secret header lets test traffic through without exposing any bypass value in the repo.

## Test plan

- [ ] Add `E2E_BYPASS_HEADER_NAME` and `E2E_BYPASS_HEADER_VALUE` keys to SOPS secret
- [ ] Add Cloudflare WAF rule: `http.request.headers["<header-name>"] eq "<value>"` → Skip challenges
- [ ] Verify Firefox e2e job passes in next deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)