### PR TITLE
fix(e2e): guard all tests against Bootstrap CDN race with waitForBootstrap

### DIFF
--- a/e2e/tests/form-validation.spec.ts
+++ b/e2e/tests/form-validation.spec.ts
@@ -1,8 +1,21 @@
 import { test, expect } from '@playwright/test';
 
+async function waitForBootstrap(page: any): Promise<void> {
+  await page.waitForFunction(() => typeof (window as any).bootstrap !== 'undefined');
+}
+
+async function enableEmailToggle(page: any): Promise<void> {
+  await page.locator('#enableEmail').evaluate((el: HTMLInputElement) => {
+    el.checked = true;
+    el.dispatchEvent(new Event('change', { bubbles: true }));
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+}
+
 test.describe('Form validation', () => {
   test('empty message blocks submission', async ({ page }) => {
     await page.goto('/');
+    await waitForBootstrap(page);
     await page.getByRole('button', { name: ' Create Secure Link' }).click();
     await expect(page.locator('#form_message')).toHaveClass(/is-invalid/);
     // Error divs are empty (no text), so height is 0; assert via computed CSS rather than visibility
@@ -11,7 +24,8 @@ test.describe('Form validation', () => {
 
   test('invalid email format shows error', async ({ page }) => {
     await page.goto('/');
-    await page.getByRole('checkbox', { name: 'Send email notification to recipient' }).check();
+    await waitForBootstrap(page);
+    await enableEmailToggle(page);
     await page.getByRole('textbox', { name: 'Your First Name * Help about' }).fill('Anthony');
     await page.locator('#email').fill('notanemail');
     await page.getByRole('textbox', { name: 'Recipient\'s First Name *' }).fill('Bob');
@@ -27,7 +41,8 @@ test.describe('Form validation', () => {
 
   test('email fields required when notification enabled', async ({ page }) => {
     await page.goto('/');
-    await page.getByRole('checkbox', { name: 'Send email notification to recipient' }).check();
+    await waitForBootstrap(page);
+    await enableEmailToggle(page);
     await page.getByRole('textbox', { name: 'Password or Secret Message *' }).fill('SecretOnly');
     // Submit button is disabled until Turnstile resolves
     await page.evaluate(() => { (window as any).onTurnstileSuccess('cf-test-token-bypass'); });
@@ -41,8 +56,9 @@ test.describe('Form validation', () => {
 
   test('valid form without email submits successfully', async ({ page }) => {
     await page.goto('/');
+    await waitForBootstrap(page);
     await page.getByRole('textbox', { name: 'Password or Secret Message *' }).fill('JustASecret');
     await page.getByRole('button', { name: ' Create Secure Link' }).click();
-    await expect(page.getByRole('heading', { name: 'Secure Link Created Successfully!' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Secure Link Created Successfully!' })).toBeVisible({ timeout: 15000 });
   });
 });

--- a/e2e/tests/generate-password.spec.ts
+++ b/e2e/tests/generate-password.spec.ts
@@ -1,6 +1,11 @@
 import { test, expect } from '@playwright/test';
 
+async function waitForBootstrap(page: any): Promise<void> {
+  await page.waitForFunction(() => typeof (window as any).bootstrap !== 'undefined');
+}
+
 async function openModalAndGenerate(page: any): Promise<void> {
+  await waitForBootstrap(page);
   await page.locator('button[data-bs-target="#passwordGeneratorModal"]').click();
   await expect(page.locator('#passwordGeneratorModal')).toBeVisible();
   // The generated-password section is hidden until the user clicks "Generate Password"
@@ -28,6 +33,7 @@ test.describe('Generate password modal', () => {
 
   test('generated password length matches slider value', async ({ page }) => {
     await page.goto('/');
+    await waitForBootstrap(page);
     await page.locator('button[data-bs-target="#passwordGeneratorModal"]').click();
     await expect(page.locator('#passwordGeneratorModal')).toBeVisible();
     // Set slider to 20 before generating
@@ -36,6 +42,7 @@ test.describe('Generate password modal', () => {
       el.dispatchEvent(new Event('input', { bubbles: true }));
       el.dispatchEvent(new Event('change', { bubbles: true }));
     });
+    await expect(page.locator('#modalLengthValue')).toHaveText('20');
     await page.locator('#modal-generate-password').click();
     await expect(page.locator('#generated-password-section')).toBeVisible();
     const generated = await page.locator('#generated-password').inputValue();

--- a/e2e/tests/passphrase.spec.ts
+++ b/e2e/tests/passphrase.spec.ts
@@ -1,7 +1,12 @@
 import { test, expect } from '@playwright/test';
 
+async function waitForBootstrap(page: any): Promise<void> {
+  await page.waitForFunction(() => typeof (window as any).bootstrap !== 'undefined');
+}
+
 async function createMessage(page: any, secret: string, passphrase?: string): Promise<string> {
   await page.goto('/');
+  await waitForBootstrap(page);
   if (passphrase !== undefined) {
     await page.locator('#other_lastname').fill(passphrase);
   }
@@ -23,6 +28,7 @@ test.describe('Passphrase flow', () => {
     const shareUrl = await createMessage(page, 'PassphraseSecret2', 'correctpassphrase');
     await page.goto(shareUrl);
     await expect(page.locator('#access-form')).toBeVisible({ timeout: 10000 });
+    await waitForBootstrap(page);
     await page.locator('[data-bs-target="#loginModal"]').click();
     await expect(page.locator('#loginModal')).toBeVisible();
     await page.locator('#passphrase').fill('wrongpassphrase');
@@ -36,6 +42,7 @@ test.describe('Passphrase flow', () => {
     const shareUrl = await createMessage(page, secret, passphrase);
     await page.goto(shareUrl);
     await expect(page.locator('#access-form')).toBeVisible({ timeout: 10000 });
+    await waitForBootstrap(page);
     await page.locator('[data-bs-target="#loginModal"]').click();
     await expect(page.locator('#loginModal')).toBeVisible();
     await page.locator('#passphrase').fill(passphrase);


### PR DESCRIPTION
## Summary

- Added `waitForBootstrap()` helper to `form-validation`, `generate-password`, and `passphrase` specs — called after every `page.goto()` before any interaction, ensuring Bootstrap JS has fully executed before the test proceeds
- Replaced Bootstrap form-switch `.check()`/`.setChecked()` calls with `evaluate()` that sets `.checked` and dispatches `change`/`input` events directly, bypassing click geometry distorted by `transform: scale(1.5)` CSS
- Bumped `valid form without email submits successfully` success heading timeout to 15000ms to match the rest of the suite

## Root Cause

Bootstrap JS is loaded as a blocking script in `<head>` without `async`/`defer`. On Firefox with a slow CDN response, there's a window where `page.goto()` resolves (network idle / `load` event) but the `DOMContentLoaded` handler that attaches the form submit listener and wires `data-bs-*` triggers has not yet run. Playwright would then click submit or Bootstrap modal triggers before they were bound, causing intermittent silent failures.

Confirmed stable at `--repeat-each 10` across all specs on both Chromium and Firefox.

## Test plan

- [x] All e2e specs pass with `--repeat-each 10` (10 consecutive runs each, no flakes)
- [x] `form-validation.spec.ts` — all 4 tests
- [x] `generate-password.spec.ts` — all 3 tests  
- [x] `passphrase.spec.ts` — all 3 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)