### PR TITLE
fix(encryption): use %w wrapping and map domain errors to gRPC codes

### DIFF
--- a/app/internal/domains/encryption/adapters/primary/grpc/server.go
+++ b/app/internal/domains/encryption/adapters/primary/grpc/server.go
@@ -38,7 +38,10 @@ func domainErrorToStatus(err error) error {
 		errors.Is(err, domain.ErrDecryptionFailed):
 		return status.Error(codes.Internal, err.Error())
 	}
-	return err
+	// Unclassified errors are server-side faults from the caller's
+	// perspective — surface as Internal rather than letting them leak
+	// out as codes.Unknown, which encourages blind client retries.
+	return status.Error(codes.Internal, err.Error())
 }
 
 // GRPCServer implements the gRPC encryption service

--- a/app/internal/domains/encryption/adapters/primary/grpc/server.go
+++ b/app/internal/domains/encryption/adapters/primary/grpc/server.go
@@ -2,17 +2,44 @@ package grpc
 
 import (
 	"context"
+	"errors"
 	"net"
 
+	"github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/domain"
 	"github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/ports/contracts"
 	"github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/ports/primary"
 	"github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/ports/secondary"
 	pb "github.com/Anthony-Bible/password-exchange/app/pkg/pb/encryption"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
+	"google.golang.org/grpc/status"
 )
+
+// domainErrorToStatus maps encryption-domain sentinel errors to typed gRPC
+// status codes. Without this, every failure surfaces as codes.Unknown and
+// clients that retry on Unknown will loop on deterministic input errors
+// (e.g., a wrong-length key).
+func domainErrorToStatus(err error) error {
+	if err == nil {
+		return nil
+	}
+	switch {
+	case errors.Is(err, domain.ErrInvalidKeyLength),
+		errors.Is(err, domain.ErrInvalidCiphertext),
+		errors.Is(err, domain.ErrBase64DecodingFailed):
+		return status.Error(codes.InvalidArgument, err.Error())
+	case errors.Is(err, domain.ErrInsufficientRandomness),
+		errors.Is(err, domain.ErrCipherCreationFailed),
+		errors.Is(err, domain.ErrGCMCreationFailed),
+		errors.Is(err, domain.ErrEncryptionFailed),
+		errors.Is(err, domain.ErrDecryptionFailed):
+		return status.Error(codes.Internal, err.Error())
+	}
+	return err
+}
 
 // GRPCServer implements the gRPC encryption service
 type GRPCServer struct {
@@ -76,7 +103,7 @@ func (s *GRPCServer) EncryptMessage(ctx context.Context, request *pb.EncryptedMe
 	response, err := s.encryptionService.Encrypt(ctx, domainRequest)
 	if err != nil {
 		s.logger.Error().Err(err).Msg("Encryption failed")
-		return nil, err
+		return nil, domainErrorToStatus(err)
 	}
 
 	pbResponse := &pb.EncryptedMessageResponse{
@@ -99,7 +126,7 @@ func (s *GRPCServer) DecryptMessage(ctx context.Context, request *pb.DecryptedMe
 	response, err := s.encryptionService.Decrypt(ctx, domainRequest)
 	if err != nil {
 		s.logger.Error().Err(err).Msg("Decryption failed")
-		return nil, err
+		return nil, domainErrorToStatus(err)
 	}
 
 	pbResponse := &pb.DecryptedMessageResponse{
@@ -121,7 +148,7 @@ func (s *GRPCServer) GenerateRandomString(ctx context.Context, request *pb.Rando
 	response, err := s.encryptionService.GenerateRandomKey(ctx, domainRequest)
 	if err != nil {
 		s.logger.Error().Err(err).Msg("Random key generation failed")
-		return nil, err
+		return nil, domainErrorToStatus(err)
 	}
 
 	pbResponse := &pb.Randomresponse{

--- a/app/internal/domains/encryption/adapters/primary/grpc/server_test.go
+++ b/app/internal/domains/encryption/adapters/primary/grpc/server_test.go
@@ -6,13 +6,16 @@ import (
 	"net"
 	"testing"
 
+	encryptiondomain "github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/domain"
 	"github.com/Anthony-Bible/password-exchange/app/internal/domains/encryption/ports/contracts"
 	"github.com/Anthony-Bible/password-exchange/app/internal/shared/logging/logtest"
 	pb "github.com/Anthony-Bible/password-exchange/app/pkg/pb/encryption"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 )
 
@@ -164,4 +167,67 @@ func TestGenerateRandomString_Error(t *testing.T) {
 
 	_, err := client.GenerateRandomString(context.Background(), &pb.Randomrequest{RandomLength: 16})
 	assert.Error(t, err)
+}
+
+func TestRPCs_MapDomainErrorsToStatus(t *testing.T) {
+	cases := []struct {
+		name      string
+		domainErr error
+		wantCode  codes.Code
+	}{
+		{"InvalidKeyLength", encryptiondomain.ErrInvalidKeyLength, codes.InvalidArgument},
+		{"InvalidCiphertext", encryptiondomain.ErrInvalidCiphertext, codes.InvalidArgument},
+		{"Base64DecodingFailed", encryptiondomain.ErrBase64DecodingFailed, codes.InvalidArgument},
+		{"InsufficientRandomness", encryptiondomain.ErrInsufficientRandomness, codes.Internal},
+		{"CipherCreationFailed", encryptiondomain.ErrCipherCreationFailed, codes.Internal},
+		{"GCMCreationFailed", encryptiondomain.ErrGCMCreationFailed, codes.Internal},
+		{"EncryptionFailed", encryptiondomain.ErrEncryptionFailed, codes.Internal},
+		{"DecryptionFailed", encryptiondomain.ErrDecryptionFailed, codes.Internal},
+	}
+
+	rpcs := []struct {
+		name string
+		call func(client pb.MessageServiceClient, svc *stubService, e error) error
+	}{
+		{
+			name: "EncryptMessage",
+			call: func(client pb.MessageServiceClient, svc *stubService, e error) error {
+				svc.encryptErr = e
+				_, err := client.EncryptMessage(context.Background(), &pb.EncryptedMessageRequest{PlainText: []string{"x"}})
+				return err
+			},
+		},
+		{
+			name: "DecryptMessage",
+			call: func(client pb.MessageServiceClient, svc *stubService, e error) error {
+				svc.decryptErr = e
+				_, err := client.DecryptMessage(context.Background(), &pb.DecryptedMessageRequest{Ciphertext: []string{"x"}})
+				return err
+			},
+		},
+		{
+			name: "GenerateRandomString",
+			call: func(client pb.MessageServiceClient, svc *stubService, e error) error {
+				svc.randomErr = e
+				_, err := client.GenerateRandomString(context.Background(), &pb.Randomrequest{RandomLength: 32})
+				return err
+			},
+		},
+	}
+
+	for _, rpc := range rpcs {
+		for _, tc := range cases {
+			t.Run(rpc.name+"_"+tc.name, func(t *testing.T) {
+				svc := &stubService{}
+				client, cleanup := startTestServer(t, svc)
+				defer cleanup()
+
+				err := rpc.call(client, svc, tc.domainErr)
+				require.Error(t, err)
+				st, ok := status.FromError(err)
+				require.True(t, ok, "expected gRPC status error, got %T: %v", err, err)
+				assert.Equal(t, tc.wantCode, st.Code(), "domain err %v should map to %v", tc.domainErr, tc.wantCode)
+			})
+		}
+	}
 }

--- a/app/internal/domains/encryption/adapters/primary/grpc/server_test.go
+++ b/app/internal/domains/encryption/adapters/primary/grpc/server_test.go
@@ -169,6 +169,18 @@ func TestGenerateRandomString_Error(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestRPCs_UnclassifiedErrorMapsToInternal(t *testing.T) {
+	svc := &stubService{encryptErr: errors.New("boom")}
+	client, cleanup := startTestServer(t, svc)
+	defer cleanup()
+
+	_, err := client.EncryptMessage(context.Background(), &pb.EncryptedMessageRequest{PlainText: []string{"x"}})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+}
+
 func TestRPCs_MapDomainErrorsToStatus(t *testing.T) {
 	cases := []struct {
 		name      string

--- a/app/internal/domains/encryption/domain/service.go
+++ b/app/internal/domains/encryption/domain/service.go
@@ -38,13 +38,13 @@ func (s *EncryptionService) Encrypt(ctx context.Context, req contracts.Encryptio
 	block, err := aes.NewCipher(req.Key)
 	if err != nil {
 		s.logger.Error().Err(err).Msg("Failed to create AES cipher")
-		return nil, fmt.Errorf("%w: %v", ErrCipherCreationFailed, err)
+		return nil, fmt.Errorf("%w: %w", ErrCipherCreationFailed, err)
 	}
 
 	gcm, err := cipher.NewGCM(block)
 	if err != nil {
 		s.logger.Error().Err(err).Msg("Failed to create GCM")
-		return nil, fmt.Errorf("%w: %v", ErrGCMCreationFailed, err)
+		return nil, fmt.Errorf("%w: %w", ErrGCMCreationFailed, err)
 	}
 
 	response := &contracts.EncryptionResponse{
@@ -55,7 +55,7 @@ func (s *EncryptionService) Encrypt(ctx context.Context, req contracts.Encryptio
 		nonce := make([]byte, gcm.NonceSize())
 		if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
 			s.logger.Error().Err(err).Msg("Failed to generate nonce")
-			return nil, fmt.Errorf("%w: %v", ErrInsufficientRandomness, err)
+			return nil, fmt.Errorf("%w: %w", ErrInsufficientRandomness, err)
 		}
 
 		ciphertext := gcm.Seal(nonce, nonce, []byte(plaintext), nil)
@@ -77,13 +77,13 @@ func (s *EncryptionService) Decrypt(ctx context.Context, req contracts.Decryptio
 	block, err := aes.NewCipher(req.Key)
 	if err != nil {
 		s.logger.Error().Err(err).Msg("Failed to create AES cipher")
-		return nil, fmt.Errorf("%w: %v", ErrCipherCreationFailed, err)
+		return nil, fmt.Errorf("%w: %w", ErrCipherCreationFailed, err)
 	}
 
 	gcm, err := cipher.NewGCM(block)
 	if err != nil {
 		s.logger.Error().Err(err).Msg("Failed to create GCM")
-		return nil, fmt.Errorf("%w: %v", ErrGCMCreationFailed, err)
+		return nil, fmt.Errorf("%w: %w", ErrGCMCreationFailed, err)
 	}
 
 	response := &contracts.DecryptionResponse{
@@ -94,7 +94,7 @@ func (s *EncryptionService) Decrypt(ctx context.Context, req contracts.Decryptio
 		ciphertext, err := base64.URLEncoding.DecodeString(encodedCiphertext)
 		if err != nil {
 			s.logger.Error().Err(err).Str("ciphertext", encodedCiphertext).Msg("Failed to decode base64 ciphertext")
-			return nil, fmt.Errorf("%w: %v", ErrBase64DecodingFailed, err)
+			return nil, fmt.Errorf("%w: %w", ErrBase64DecodingFailed, err)
 		}
 
 		if len(ciphertext) < gcm.NonceSize() {
@@ -108,7 +108,7 @@ func (s *EncryptionService) Decrypt(ctx context.Context, req contracts.Decryptio
 		plaintext, err := gcm.Open(nil, nonce, encryptedData, nil)
 		if err != nil {
 			s.logger.Error().Err(err).Msg("Failed to decrypt message")
-			return nil, fmt.Errorf("%w: %v", ErrDecryptionFailed, err)
+			return nil, fmt.Errorf("%w: %w", ErrDecryptionFailed, err)
 		}
 
 		encodedPlaintext := base64.URLEncoding.EncodeToString(plaintext)


### PR DESCRIPTION
Two independent bugs in the encryption domain (split from #371):

1. service.go wrapped causes with %v inside %w-wrapped sentinels, which stringifies the inner error and breaks errors.Is/As against the underlying cause. Switch every site to %w/%w so the chain survives.

2. The gRPC server returned raw domain errors, so clients saw codes.Unknown for every failure (and would retry deterministic input errors forever). Add domainErrorToStatus mirroring the storage server, mapping input sentinels to InvalidArgument and internal failures to Internal, and wire it through all three RPC handlers.

Adds table-driven tests over EncryptMessage, DecryptMessage, and GenerateRandomString covering every mapped sentinel.

Closes #527