### PR TITLE
feat(message): replace hardcoded default view count with dynamic config value

### DIFF
--- a/app/internal/domains/message/adapters/primary/api/handlers_test.go
+++ b/app/internal/domains/message/adapters/primary/api/handlers_test.go
@@ -58,6 +58,11 @@ func (m *MockMessageService) NotifyMessage(
 	return args.Error(0)
 }
 
+func (m *MockMessageService) GetDefaultMaxViewCount() int {
+	args := m.Called()
+	return args.Int(0)
+}
+
 // healthCheckFn is a tiny test-only function-typed implementation of the
 // HealthCheck contract for both secondary ports. Tests inject a closure that
 // returns the desired error/timing behaviour without standing up a full mock.

--- a/app/internal/domains/message/adapters/primary/web/discovery_test.go
+++ b/app/internal/domains/message/adapters/primary/web/discovery_test.go
@@ -14,6 +14,7 @@ import (
 func newDiscoveryEngine() (*gin.Engine, *MessageHandler) {
 	gin.SetMode(gin.TestMode)
 	mockService := new(MockMessageService)
+	mockService.On("GetDefaultMaxViewCount").Return(5).Maybe()
 	handler := NewMessageHandler(mockService)
 	engine := gin.New()
 	engine.SetHTMLTemplate(createMockTemplate())

--- a/app/internal/domains/message/adapters/primary/web/handlers.go
+++ b/app/internal/domains/message/adapters/primary/web/handlers.go
@@ -234,7 +234,8 @@ func (h *MessageHandler) Home(c *gin.Context) {
 	c.Writer.Header().Add("Link", `</.well-known/api-catalog>; rel="api-catalog"`)
 	c.Writer.Header().Add("Link", `</api/v1/docs/index.html>; rel="service-doc"`)
 	data := gin.H{
-		"Title": "Password Exchange",
+		"Title":               "Password Exchange",
+		"DefaultMaxViewCount": h.messageService.GetDefaultMaxViewCount(),
 	}
 	h.renderHTMLOrMarkdown(c, http.StatusOK, "home.html", data, nil)
 }
@@ -249,8 +250,9 @@ func (h *MessageHandler) About(c *gin.Context) {
 func (h *MessageHandler) Confirmation(c *gin.Context) {
 	content := c.Query("content")
 	data := gin.H{
-		"Title": "passwordExchange",
-		"Url":   content,
+		"Title":               "passwordExchange",
+		"Url":                 content,
+		"DefaultMaxViewCount": h.messageService.GetDefaultMaxViewCount(),
 	}
 	h.renderHTMLOrMarkdown(c, http.StatusOK, "confirmation.html", data, nil)
 }
@@ -274,8 +276,9 @@ func (h *MessageHandler) renderError(c *gin.Context, message string, err error) 
 	logging.Error().Err(err).Str("message", message).Msg("Rendering error page")
 
 	data := gin.H{
-		"Title":  "Error - Password Exchange",
-		"Errors": map[string]string{"general": message},
+		"Title":               "Error - Password Exchange",
+		"Errors":              map[string]string{"general": message},
+		"DefaultMaxViewCount": h.messageService.GetDefaultMaxViewCount(),
 	}
 
 	h.renderHTMLOrMarkdown(c, http.StatusInternalServerError, "home.html", data, nil)
@@ -285,8 +288,9 @@ func (h *MessageHandler) renderErrorWithField(c *gin.Context, message string, fi
 	logging.Error().Str("message", message).Str("field", field).Msg("Rendering validation error page")
 
 	data := gin.H{
-		"Title":  "Password Exchange",
-		"Errors": map[string]string{field: message},
+		"Title":               "Password Exchange",
+		"Errors":              map[string]string{field: message},
+		"DefaultMaxViewCount": h.messageService.GetDefaultMaxViewCount(),
 	}
 
 	h.renderHTMLOrMarkdown(c, http.StatusBadRequest, "home.html", data, nil)

--- a/app/internal/domains/message/adapters/primary/web/handlers_test.go
+++ b/app/internal/domains/message/adapters/primary/web/handlers_test.go
@@ -58,6 +58,149 @@ func (m *MockMessageService) NotifyMessage(
 	return args.Error(0)
 }
 
+func (m *MockMessageService) GetDefaultMaxViewCount() int {
+	args := m.Called()
+	return args.Int(0)
+}
+
+// TestHome_PassesDefaultMaxViewCountToTemplate verifies that the Home handler
+// includes the DefaultMaxViewCount value from the service in the template data
+// so the placeholder is dynamic rather than hardcoded.
+func TestHome_PassesDefaultMaxViewCountToTemplate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	mockService := new(MockMessageService)
+	handler := NewMessageHandler(mockService)
+
+	mockService.On("GetDefaultMaxViewCount").Return(7)
+
+	// Use a template that explicitly renders DefaultMaxViewCount so we can assert
+	// the value is present in the output.
+	tmpl := template.New("templates")
+	tmpl, _ = tmpl.New("home.html").Parse(
+		`<html><body><span id="default-view-count">{{.DefaultMaxViewCount}}</span></body></html>`,
+	)
+
+	router := gin.New()
+	router.SetHTMLTemplate(tmpl)
+	router.GET("/", handler.Home)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "7",
+		"Home handler must pass DefaultMaxViewCount from service into template data")
+	mockService.AssertCalled(t, "GetDefaultMaxViewCount")
+	mockService.AssertExpectations(t)
+}
+
+// TestHome_ErrorPath_PassesDefaultMaxViewCountToTemplate verifies that
+// renderError (called on SubmitMessage failure) also includes DefaultMaxViewCount
+// in the data map so the home template re-render after an error stays dynamic.
+func TestHome_ErrorPath_PassesDefaultMaxViewCountToTemplate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	mockService := new(MockMessageService)
+	handler := NewMessageHandler(mockService)
+
+	mockService.On("GetDefaultMaxViewCount").Return(3)
+	mockService.On("SubmitMessage", mock.Anything, mock.Anything).
+		Return((*domain.MessageSubmissionResponse)(nil), domain.ErrInvalidMessageRequest)
+
+	tmpl := template.New("templates")
+	tmpl, _ = tmpl.New("home.html").Parse(
+		`<html><body><span id="default-view-count">{{.DefaultMaxViewCount}}</span></body></html>`,
+	)
+
+	router := gin.New()
+	router.SetHTMLTemplate(tmpl)
+	router.POST("/submit", handler.SubmitMessage)
+
+	formData := url.Values{}
+	formData.Set("content", "test message")
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/submit", strings.NewReader(formData.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	router.ServeHTTP(w, req)
+
+	assert.Contains(t, w.Body.String(), "3",
+		"renderError must pass DefaultMaxViewCount from service into home.html template data")
+	mockService.AssertCalled(t, "GetDefaultMaxViewCount")
+	mockService.AssertExpectations(t)
+}
+
+// TestHome_ValidationErrorPath_PassesDefaultMaxViewCountToTemplate verifies
+// that renderErrorWithField (called on form validation failure) includes
+// DefaultMaxViewCount so the home template re-render stays dynamic.
+func TestHome_ValidationErrorPath_PassesDefaultMaxViewCountToTemplate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	mockService := new(MockMessageService)
+	handler := NewMessageHandler(mockService)
+
+	mockService.On("GetDefaultMaxViewCount").Return(10)
+
+	tmpl := template.New("templates")
+	tmpl, _ = tmpl.New("home.html").Parse(
+		`<html><body><span id="default-view-count">{{.DefaultMaxViewCount}}</span></body></html>`,
+	)
+
+	engine := gin.New()
+	engine.SetHTMLTemplate(tmpl)
+
+	// Submit a non-numeric max_view_count to trigger renderErrorWithField
+	formData := url.Values{}
+	formData.Set("content", "test message")
+	formData.Set("max_view_count", "not-a-number")
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/submit", strings.NewReader(formData.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	c := gin.CreateTestContextOnly(w, engine)
+	c.Request = req
+
+	handler.SubmitMessage(c)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "10",
+		"renderErrorWithField must pass DefaultMaxViewCount from service into home.html template data")
+	mockService.AssertCalled(t, "GetDefaultMaxViewCount")
+	mockService.AssertExpectations(t)
+}
+
+// TestConfirmation_PassesDefaultMaxViewCountToTemplate verifies that the
+// Confirmation handler includes DefaultMaxViewCount in template data so any
+// hardcoded view count references in confirmation.html can be made dynamic.
+func TestConfirmation_PassesDefaultMaxViewCountToTemplate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	mockService := new(MockMessageService)
+	handler := NewMessageHandler(mockService)
+
+	mockService.On("GetDefaultMaxViewCount").Return(5)
+
+	tmpl := template.New("templates")
+	tmpl, _ = tmpl.New("confirmation.html").Parse(
+		`<html><body><span id="default-view-count">{{.DefaultMaxViewCount}}</span></body></html>`,
+	)
+
+	router := gin.New()
+	router.SetHTMLTemplate(tmpl)
+	router.GET("/confirmation", handler.Confirmation)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/confirmation?content=https://password.exchange/test", nil)
+
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "5",
+		"Confirmation handler must pass DefaultMaxViewCount from service into template data")
+	mockService.AssertCalled(t, "GetDefaultMaxViewCount")
+	mockService.AssertExpectations(t)
+}
+
 func TestDisplayDecrypted_ShouldNotCallRetrieveMessage(t *testing.T) {
 	// This test verifies the fix: DisplayDecrypted should NOT call RetrieveMessage
 	// regardless of whether a passphrase is required or not

--- a/app/internal/domains/message/adapters/primary/web/handlers_test.go
+++ b/app/internal/domains/message/adapters/primary/web/handlers_test.go
@@ -363,6 +363,8 @@ func TestSubmitMessage_MaxViewCountValidation(t *testing.T) {
 			mockService := new(MockMessageService)
 			handler := NewMessageHandler(mockService)
 
+			mockService.On("GetDefaultMaxViewCount").Return(5).Maybe()
+
 			if tc.expectServiceCall {
 				expectedMaxViewCount := 0
 				if tc.maxViewCountValue != "" {
@@ -436,6 +438,7 @@ func TestHTMLEndpoints_DefaultBrowserBehaviorReturnsHTML(t *testing.T) {
 		Exists:             true,
 		RequiresPassphrase: false,
 	}, nil)
+	mockService.On("GetDefaultMaxViewCount").Return(5).Maybe()
 
 	router := gin.New()
 	router.SetHTMLTemplate(createMockTemplate())
@@ -482,6 +485,7 @@ func TestHTMLEndpoints_AcceptNegotiationContracts(t *testing.T) {
 		Exists:             true,
 		RequiresPassphrase: false,
 	}, nil)
+	mockService.On("GetDefaultMaxViewCount").Return(5).Maybe()
 
 	router := gin.New()
 	router.SetHTMLTemplate(createMockTemplate())
@@ -738,6 +742,7 @@ func TestMarkdownPath_StripsScriptsAndStyles(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	mockService := new(MockMessageService)
 	handler := NewMessageHandler(mockService)
+	mockService.On("GetDefaultMaxViewCount").Return(5).Maybe()
 
 	tmpl := template.New("templates")
 	tmpl, _ = tmpl.New("home.html").Parse(
@@ -772,6 +777,7 @@ func TestMarkdownPath_VaryHeaderMergesWithUpstream(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	mockService := new(MockMessageService)
 	handler := NewMessageHandler(mockService)
+	mockService.On("GetDefaultMaxViewCount").Return(5).Maybe()
 
 	router := gin.New()
 	router.SetHTMLTemplate(createMockTemplate())

--- a/app/internal/domains/message/domain/message_service.go
+++ b/app/internal/domains/message/domain/message_service.go
@@ -425,6 +425,14 @@ func (s *MessageService) NotifyMessage(ctx context.Context, req MessageNotifyReq
 	return nil
 }
 
+// GetDefaultMaxViewCount returns the configured default maximum view count for new messages.
+func (s *MessageService) GetDefaultMaxViewCount() int {
+	if v := s.config.GetDefaultMaxViewCount(); v > 0 {
+		return v
+	}
+	return DefaultMaxViewCount
+}
+
 // validateSubmissionRequest validates the message submission request.
 func (s *MessageService) validateSubmissionRequest(req MessageSubmissionRequest) error {
 	if strings.TrimSpace(req.Content) == "" {

--- a/app/internal/domains/message/domain/message_service_test.go
+++ b/app/internal/domains/message/domain/message_service_test.go
@@ -672,6 +672,53 @@ func TestNotifyMessage_InvalidTurnstileToken(t *testing.T) {
 	notif.AssertNotCalled(t, "SendMessageNotification", mock.Anything, mock.Anything)
 }
 
+// TestGetDefaultMaxViewCount_ReturnsConfigValue verifies that the service
+// delegates to the config port and returns whatever value it provides.
+func TestGetDefaultMaxViewCount_ReturnsConfigValue(t *testing.T) {
+	enc, stor, notif, hasher, urlb, turnstile, logger, config, validation := createTestMocks()
+	setupLenientLoggerMock(logger)
+	validation.On("SanitizeEmailForLogging", mock.Anything).Return("sanitized-email@example.com").Maybe()
+	config.On("GetDefaultMaxViewCount").Return(12)
+
+	svc := NewMessageService(enc, stor, notif, hasher, urlb, turnstile, logger, config, validation)
+
+	got := svc.GetDefaultMaxViewCount()
+	assert.Equal(t, 12, got, "GetDefaultMaxViewCount must return the value from the config port")
+	config.AssertCalled(t, "GetDefaultMaxViewCount")
+}
+
+// TestGetDefaultMaxViewCount_FallsBackToConstantWhenConfigReturnsZero verifies
+// that when the config port returns a non-positive value the service falls back
+// to the DefaultMaxViewCount domain constant (5) rather than propagating an
+// invalid zero or negative value to callers.
+func TestGetDefaultMaxViewCount_FallsBackToConstantWhenConfigReturnsZero(t *testing.T) {
+	enc, stor, notif, hasher, urlb, turnstile, logger, config, validation := createTestMocks()
+	setupLenientLoggerMock(logger)
+	validation.On("SanitizeEmailForLogging", mock.Anything).Return("sanitized-email@example.com").Maybe()
+	config.On("GetDefaultMaxViewCount").Return(0)
+
+	svc := NewMessageService(enc, stor, notif, hasher, urlb, turnstile, logger, config, validation)
+
+	got := svc.GetDefaultMaxViewCount()
+	assert.Equal(t, DefaultMaxViewCount, got,
+		"GetDefaultMaxViewCount must fall back to DefaultMaxViewCount constant when config returns 0")
+}
+
+// TestGetDefaultMaxViewCount_FallsBackToConstantWhenConfigReturnsNegative
+// is the negative-input variant of the fallback contract.
+func TestGetDefaultMaxViewCount_FallsBackToConstantWhenConfigReturnsNegative(t *testing.T) {
+	enc, stor, notif, hasher, urlb, turnstile, logger, config, validation := createTestMocks()
+	setupLenientLoggerMock(logger)
+	validation.On("SanitizeEmailForLogging", mock.Anything).Return("sanitized-email@example.com").Maybe()
+	config.On("GetDefaultMaxViewCount").Return(-3)
+
+	svc := NewMessageService(enc, stor, notif, hasher, urlb, turnstile, logger, config, validation)
+
+	got := svc.GetDefaultMaxViewCount()
+	assert.Equal(t, DefaultMaxViewCount, got,
+		"GetDefaultMaxViewCount must fall back to DefaultMaxViewCount constant when config returns a negative value")
+}
+
 func TestNotifyMessage_MessageNotFound(t *testing.T) {
 	enc, stor, notif, hasher, urlb, turnstile, logger, config, validation := createTestMocks()
 	setupTestMocks(enc, stor, notif, hasher, urlb, turnstile, logger, config, validation)

--- a/app/internal/domains/message/ports/primary/message_service.go
+++ b/app/internal/domains/message/ports/primary/message_service.go
@@ -21,4 +21,7 @@ type MessageServicePort interface {
 	// caller-supplied ShareURL so that file-download fragments (#fid=, #fk=) built
 	// after the initial message creation are included in the notification link.
 	NotifyMessage(ctx context.Context, req domain.MessageNotifyRequest) error
+
+	// GetDefaultMaxViewCount returns the configured default maximum view count for new messages.
+	GetDefaultMaxViewCount() int
 }

--- a/app/templates/confirmation.html
+++ b/app/templates/confirmation.html
@@ -28,8 +28,8 @@
                     Important Security Notes
                 </h6>
                 <ul class="mb-0">
-                    <li>This link can be accessed up to <strong>5 times</strong></li>
-                    <li>The message will be permanently deleted after 5 views</li>
+                    <li>This link can be accessed up to <strong>{{.DefaultMaxViewCount}} times</strong></li>
+                    <li>The message will be permanently deleted after {{.DefaultMaxViewCount}} views</li>
                     <li>Share this link through a secure channel</li>
                 </ul>
             </div>

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -148,12 +148,12 @@
                                    type="number" 
                                    name="max_view_count" 
                                    class="form-control" 
-                                   placeholder="5"
+                                   placeholder="{{.DefaultMaxViewCount}}"
                                    min="1"
                                    max="100"
                                    aria-describedby="maxViewCountHelp maxViewCountError">
                             <div id="maxViewCountHelp" class="form-text">
-                                Leave empty to use default (5 views)
+                                Leave empty to use default ({{.DefaultMaxViewCount}} views)
                             </div>
                             <div id="maxViewCountError" class="invalid-feedback"></div>
                         </div>


### PR DESCRIPTION
## Summary
- Resolves #348
- Added `GetDefaultMaxViewCount() int` to `MessageServicePort` interface, implemented on `MessageService` (delegates to config with `DefaultMaxViewCount` constant fallback)
- Web handler passes `DefaultMaxViewCount` to template data in `Home()`, `Confirmation()`, `renderError()`, and `renderErrorWithField()`
- `home.html` placeholder and help text now use `{{.DefaultMaxViewCount}}` instead of hardcoded `5`
- `confirmation.html` security notes now use `{{.DefaultMaxViewCount}}` for both occurrences

## Test plan
- [ ] All existing tests pass (`go test ./...`)
- [ ] New domain service tests: `GetDefaultMaxViewCount()` returns config value when set, falls back to constant when config returns ≤ 0
- [ ] New handler tests: `Home()`, `Confirmation()`, error paths all pass `DefaultMaxViewCount` in template data
- [ ] Change config default and confirm UI reflects the new value

🤖 Generated with [Claude Code](https://claude.com/claude-code)