### PR TITLE
test(message/s3): unit + Garage integration tests for S3 adapter (#531)

### DIFF
--- a/app/go.mod
+++ b/app/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/mysql v0.42.0
 	github.com/ulule/limiter/v3 v3.11.2
 	golang.org/x/crypto v0.51.0
+	golang.org/x/sync v0.20.0
 	golang.org/x/text v0.37.0
 	google.golang.org/grpc v1.79.3
 	google.golang.org/protobuf v1.36.10
@@ -139,7 +140,6 @@ require (
 	golang.org/x/arch v0.17.0 // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect

--- a/app/go.sum
+++ b/app/go.sum
@@ -12,8 +12,6 @@ github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7Oputl
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/JohannesKaufmann/dom v0.2.0 h1:1bragmEb19K8lHAqgFgqCpiPCFEZMTXzOIEjuxkUfLQ=
 github.com/JohannesKaufmann/dom v0.2.0/go.mod h1:57iSUl5RKric4bUkgos4zu6Xt5LMHUnw3TF1l5CbGZo=
-github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.0 h1:mklaPbT4f/EiDr1Q+zPrEt9lgKAkVrIBtWf33d9GpVA=
-github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.0/go.mod h1:D56Cl9r8M5i3UwAchE+LlLc5hPN3kJtdZNVJn06lSHU=
 github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.1 h1:IpUgup6ucCE4wB59wAP0Y2qSApYjFhSfGVjShUBoVSw=
 github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.1/go.mod h1:KUwy/WLgv9kv2yeBZkPCgDokHzg0M6EdRc17thnbVFw=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
@@ -170,8 +168,6 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.6 h1:8yTIVnZgCoiM1TgqoeTl+LfU5Jg6/xL3QhGQnimLYnA=
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
-github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw4=
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/mattn/go-sqlite3 v1.14.44 h1:3VSe+xafpbzsLbdr2AWlAZk9yRHiBhTBakioXaCKTF8=
@@ -303,8 +299,8 @@ github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZ
 github.com/ulule/limiter/v3 v3.11.2 h1:P4yOrxoEMJbOTfRJR2OzjL90oflzYPPmWg+dvwN2tHA=
 github.com/ulule/limiter/v3 v3.11.2/go.mod h1:QG5GnFOCV+k7lrL5Y8kgEeeflPH3+Cviqlqa8SVSQxI=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-github.com/yuin/goldmark v1.7.13 h1:GPddIs617DnBLFFVJFgpo1aBfe/4xcvMc3SB5t/D0pA=
-github.com/yuin/goldmark v1.7.13/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
+github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
+github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
@@ -363,7 +359,6 @@ golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
 golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/app/internal/domains/message/adapters/secondary/s3/object_storage.go
+++ b/app/internal/domains/message/adapters/secondary/s3/object_storage.go
@@ -13,11 +13,39 @@ import (
 
 var _ secondary.ObjectStoragePort = (*S3Adapter)(nil)
 
+// multipartCore is satisfied by *minio.Core and allows unit tests to inject a fake.
+type multipartCore interface {
+	NewMultipartUpload(ctx context.Context, bucket, object string, opts minio.PutObjectOptions) (string, error)
+	PutObjectPart(ctx context.Context, bucket, object, uploadID string, partID int, data io.Reader, size int64, opts minio.PutObjectPartOptions) (minio.ObjectPart, error)
+	CompleteMultipartUpload(ctx context.Context, bucket, object, uploadID string, parts []minio.CompletePart, opts minio.PutObjectOptions) (minio.UploadInfo, error)
+	AbortMultipartUpload(ctx context.Context, bucket, object, uploadID string) error
+}
+
+// readerStat is satisfied by *minio.Object; it combines io.ReadCloser with the
+// Stat method needed to retrieve object metadata before streaming.
+type readerStat interface {
+	io.ReadCloser
+	Stat() (minio.ObjectInfo, error)
+}
+
+// objectGetter abstracts *minio.Client.GetObject so tests can inject a fake.
+type objectGetter interface {
+	GetObject(ctx context.Context, bucket, object string, opts minio.GetObjectOptions) (readerStat, error)
+}
+
+// minioObjectGetter wraps *minio.Client so its GetObject return type satisfies
+// objectGetter (which returns readerStat instead of *minio.Object).
+type minioObjectGetter struct{ client *minio.Client }
+
+func (g *minioObjectGetter) GetObject(ctx context.Context, bucket, object string, opts minio.GetObjectOptions) (readerStat, error) {
+	return g.client.GetObject(ctx, bucket, object, opts)
+}
+
 // S3Adapter implements ObjectStoragePort with an S3-compatible backend.
 type S3Adapter struct {
-	s3Client *minio.Client
-	core     *minio.Core
-	bucket   string
+	getter objectGetter
+	core   multipartCore
+	bucket string
 }
 
 // NewS3Adapter creates a new S3-compatible object storage adapter.
@@ -38,9 +66,9 @@ func NewS3Adapter(endpoint, accessKeyID, secretAccessKey, bucket string, useSSL 
 	}
 
 	return &S3Adapter{
-		s3Client: s3Client,
-		core:     coreClient,
-		bucket:   bucket,
+		getter: &minioObjectGetter{client: s3Client},
+		core:   coreClient,
+		bucket: bucket,
 	}, nil
 }
 
@@ -76,7 +104,7 @@ func (a *S3Adapter) AbortMultipartUpload(ctx context.Context, fileID, uploadID s
 
 // GetObject retrieves the stored object and returns its size.
 func (a *S3Adapter) GetObject(ctx context.Context, fileID string) (io.ReadCloser, int64, error) {
-	obj, err := a.s3Client.GetObject(ctx, a.bucket, fileID, minio.GetObjectOptions{})
+	obj, err := a.getter.GetObject(ctx, a.bucket, fileID, minio.GetObjectOptions{})
 	if err != nil {
 		return nil, 0, err
 	}

--- a/app/internal/domains/message/adapters/secondary/s3/object_storage_integration_test.go
+++ b/app/internal/domains/message/adapters/secondary/s3/object_storage_integration_test.go
@@ -1,0 +1,139 @@
+//go:build integration
+
+package s3_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
+	"testing"
+
+	s3adapter "github.com/Anthony-Bible/password-exchange/app/internal/domains/message/adapters/secondary/s3"
+	"github.com/Anthony-Bible/password-exchange/app/internal/domains/message/ports/contracts"
+	"github.com/Anthony-Bible/password-exchange/app/internal/integration/garagetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// s3MinPartSize is the minimum non-final part size enforced by S3 (5 MiB).
+	s3MinPartSize = 5 * 1024 * 1024
+)
+
+// sharedAdapter is created once in TestMain and reused by all integration tests.
+// Each test uses a unique fileID so there is no cross-test state.
+var sharedAdapter *s3adapter.S3Adapter
+
+func TestMain(m *testing.M) {
+	endpoint, accessKey, secretKey, bucket, teardown := garagetest.MustStart()
+
+	var err error
+	sharedAdapter, err = s3adapter.NewS3Adapter(endpoint, accessKey, secretKey, bucket, false)
+	if err != nil {
+		log.Fatalf("garagetest: create S3 adapter: %v", err)
+	}
+
+	code := m.Run()
+	teardown()
+	os.Exit(code)
+}
+
+func uniqueFileID(t *testing.T, suffix string) string {
+	t.Helper()
+	name := strings.NewReplacer("/", "-", " ", "-").Replace(t.Name())
+	return fmt.Sprintf("%s-%s", name, suffix)
+}
+
+func sha256hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return fmt.Sprintf("%x", sum)
+}
+
+func TestIntegration_MultipartRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	fileID := uniqueFileID(t, "roundtrip")
+	uploadID, err := sharedAdapter.InitiateMultipartUpload(ctx, fileID, "application/octet-stream")
+	require.NoError(t, err, "initiate multipart upload")
+
+	// Part 1: exactly 5 MiB (S3 minimum for non-final parts).
+	part1Data := bytes.Repeat([]byte("A"), s3MinPartSize)
+	// Part 2: ~1 KiB final part.
+	part2Data := bytes.Repeat([]byte("B"), 1024)
+
+	etag1, err := sharedAdapter.UploadPart(ctx, fileID, uploadID, 1, part1Data)
+	require.NoError(t, err, "upload part 1")
+	assert.NotEmpty(t, etag1)
+
+	etag2, err := sharedAdapter.UploadPart(ctx, fileID, uploadID, 2, part2Data)
+	require.NoError(t, err, "upload part 2")
+	assert.NotEmpty(t, etag2)
+
+	err = sharedAdapter.CompleteMultipartUpload(ctx, fileID, uploadID, []contracts.CompletedPart{
+		{PartNumber: 1, ETag: etag1},
+		{PartNumber: 2, ETag: etag2},
+	})
+	require.NoError(t, err, "complete multipart upload")
+
+	expected := append(part1Data, part2Data...)
+	expectedHash := sha256hex(expected)
+	expectedSize := int64(len(expected))
+
+	rc, size, err := sharedAdapter.GetObject(ctx, fileID)
+	require.NoError(t, err, "get object")
+	defer rc.Close()
+
+	assert.Equal(t, expectedSize, size)
+
+	got, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, expectedHash, sha256hex(got), "content hash mismatch")
+}
+
+func TestIntegration_AbortDiscardsUpload(t *testing.T) {
+	ctx := context.Background()
+
+	fileID := uniqueFileID(t, "abort")
+	uploadID, err := sharedAdapter.InitiateMultipartUpload(ctx, fileID, "application/octet-stream")
+	require.NoError(t, err)
+
+	// Upload one part so there is staged data to discard.
+	partData := bytes.Repeat([]byte("C"), s3MinPartSize)
+	_, err = sharedAdapter.UploadPart(ctx, fileID, uploadID, 1, partData)
+	require.NoError(t, err)
+
+	err = sharedAdapter.AbortMultipartUpload(ctx, fileID, uploadID)
+	require.NoError(t, err, "abort multipart upload")
+
+	// The object must not exist after an abort.
+	_, _, err = sharedAdapter.GetObject(ctx, fileID)
+	assert.Error(t, err, "GetObject after abort should error (object does not exist)")
+}
+
+func TestIntegration_GetObjectMissing(t *testing.T) {
+	_, _, err := sharedAdapter.GetObject(context.Background(), uniqueFileID(t, "missing"))
+	assert.Error(t, err, "GetObject for a non-existent key should return an error")
+}
+
+func TestIntegration_CompleteWithBadETag(t *testing.T) {
+	ctx := context.Background()
+
+	fileID := uniqueFileID(t, "badeTag")
+	uploadID, err := sharedAdapter.InitiateMultipartUpload(ctx, fileID, "application/octet-stream")
+	require.NoError(t, err)
+
+	partData := bytes.Repeat([]byte("D"), s3MinPartSize)
+	_, err = sharedAdapter.UploadPart(ctx, fileID, uploadID, 1, partData)
+	require.NoError(t, err)
+
+	// Deliberately supply a wrong ETag — S3 must reject the completion.
+	err = sharedAdapter.CompleteMultipartUpload(ctx, fileID, uploadID, []contracts.CompletedPart{
+		{PartNumber: 1, ETag: "\"not-a-real-etag\""},
+	})
+	assert.Error(t, err, "CompleteMultipartUpload with a bad ETag should error")
+}

--- a/app/internal/domains/message/adapters/secondary/s3/object_storage_test.go
+++ b/app/internal/domains/message/adapters/secondary/s3/object_storage_test.go
@@ -1,0 +1,333 @@
+package s3
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/Anthony-Bible/password-exchange/app/internal/domains/message/ports/contracts"
+	"github.com/minio/minio-go/v7"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeCore implements multipartCore with function fields so each test can
+// configure exactly the behavior it needs.
+type fakeCore struct {
+	newMultipartUploadFn      func(ctx context.Context, bucket, object string, opts minio.PutObjectOptions) (string, error)
+	putObjectPartFn           func(ctx context.Context, bucket, object, uploadID string, partID int, data io.Reader, size int64, opts minio.PutObjectPartOptions) (minio.ObjectPart, error)
+	completeMultipartUploadFn func(ctx context.Context, bucket, object, uploadID string, parts []minio.CompletePart, opts minio.PutObjectOptions) (minio.UploadInfo, error)
+	abortMultipartUploadFn    func(ctx context.Context, bucket, object, uploadID string) error
+}
+
+func (f *fakeCore) NewMultipartUpload(ctx context.Context, bucket, object string, opts minio.PutObjectOptions) (string, error) {
+	return f.newMultipartUploadFn(ctx, bucket, object, opts)
+}
+
+func (f *fakeCore) PutObjectPart(ctx context.Context, bucket, object, uploadID string, partID int, data io.Reader, size int64, opts minio.PutObjectPartOptions) (minio.ObjectPart, error) {
+	return f.putObjectPartFn(ctx, bucket, object, uploadID, partID, data, size, opts)
+}
+
+func (f *fakeCore) CompleteMultipartUpload(ctx context.Context, bucket, object, uploadID string, parts []minio.CompletePart, opts minio.PutObjectOptions) (minio.UploadInfo, error) {
+	return f.completeMultipartUploadFn(ctx, bucket, object, uploadID, parts, opts)
+}
+
+func (f *fakeCore) AbortMultipartUpload(ctx context.Context, bucket, object, uploadID string) error {
+	return f.abortMultipartUploadFn(ctx, bucket, object, uploadID)
+}
+
+// fakeGetter implements objectGetter with a function field.
+type fakeGetter struct {
+	getObjectFn func(ctx context.Context, bucket, object string, opts minio.GetObjectOptions) (readerStat, error)
+}
+
+func (g *fakeGetter) GetObject(ctx context.Context, bucket, object string, opts minio.GetObjectOptions) (readerStat, error) {
+	return g.getObjectFn(ctx, bucket, object, opts)
+}
+
+// fakeReaderStat implements readerStat backed by a bytes.Reader; it records
+// whether Close was called so tests can assert the close-on-stat-error path.
+type fakeReaderStat struct {
+	reader *bytes.Reader
+	size   int64
+	statFn func() (minio.ObjectInfo, error)
+	closed bool
+}
+
+func (f *fakeReaderStat) Read(p []byte) (int, error)      { return f.reader.Read(p) }
+func (f *fakeReaderStat) Close() error                    { f.closed = true; return nil }
+func (f *fakeReaderStat) Stat() (minio.ObjectInfo, error) { return f.statFn() }
+
+// newTestAdapter builds an S3Adapter with the given fakes and a fixed bucket name.
+func newTestAdapter(core multipartCore, getter objectGetter) *S3Adapter {
+	return &S3Adapter{core: core, getter: getter, bucket: "test-bucket"}
+}
+
+// ---------- InitiateMultipartUpload ----------
+
+func TestInitiateMultipartUpload_Happy(t *testing.T) {
+	t.Parallel()
+	var gotBucket, gotObject, gotContentType string
+	core := &fakeCore{
+		newMultipartUploadFn: func(_ context.Context, bucket, object string, opts minio.PutObjectOptions) (string, error) {
+			gotBucket = bucket
+			gotObject = object
+			gotContentType = opts.ContentType
+			return "upload-id-1", nil
+		},
+	}
+	a := newTestAdapter(core, nil)
+
+	id, err := a.InitiateMultipartUpload(context.Background(), "file-abc", "application/octet-stream")
+
+	require.NoError(t, err)
+	assert.Equal(t, "upload-id-1", id)
+	assert.Equal(t, "test-bucket", gotBucket)
+	assert.Equal(t, "file-abc", gotObject)
+	assert.Equal(t, "application/octet-stream", gotContentType)
+}
+
+func TestInitiateMultipartUpload_Error(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("s3 unavailable")
+	core := &fakeCore{
+		newMultipartUploadFn: func(_ context.Context, _, _ string, _ minio.PutObjectOptions) (string, error) {
+			return "", boom
+		},
+	}
+	a := newTestAdapter(core, nil)
+
+	id, err := a.InitiateMultipartUpload(context.Background(), "file-abc", "application/octet-stream")
+
+	assert.ErrorIs(t, err, boom)
+	assert.Empty(t, id)
+}
+
+// ---------- UploadPart ----------
+
+func TestUploadPart_Happy(t *testing.T) {
+	t.Parallel()
+	payload := []byte("chunk-data")
+	var gotPartID int
+	var gotSize int64
+	var gotData []byte
+
+	core := &fakeCore{
+		putObjectPartFn: func(_ context.Context, _, _, _ string, partID int, data io.Reader, size int64, _ minio.PutObjectPartOptions) (minio.ObjectPart, error) {
+			gotPartID = partID
+			gotSize = size
+			gotData, _ = io.ReadAll(data)
+			return minio.ObjectPart{ETag: "etag-part-1"}, nil
+		},
+	}
+	a := newTestAdapter(core, nil)
+
+	etag, err := a.UploadPart(context.Background(), "file-abc", "upload-id-1", 1, payload)
+
+	require.NoError(t, err)
+	assert.Equal(t, "etag-part-1", etag)
+	assert.Equal(t, 1, gotPartID)
+	assert.Equal(t, int64(len(payload)), gotSize)
+	assert.Equal(t, payload, gotData)
+}
+
+func TestUploadPart_Error(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("part upload failed")
+	core := &fakeCore{
+		putObjectPartFn: func(_ context.Context, _, _, _ string, _ int, _ io.Reader, _ int64, _ minio.PutObjectPartOptions) (minio.ObjectPart, error) {
+			return minio.ObjectPart{}, boom
+		},
+	}
+	a := newTestAdapter(core, nil)
+
+	etag, err := a.UploadPart(context.Background(), "file-abc", "upload-id-1", 1, []byte("data"))
+
+	assert.ErrorIs(t, err, boom)
+	assert.Empty(t, etag)
+}
+
+// ---------- CompleteMultipartUpload ----------
+
+func TestCompleteMultipartUpload_MapsPartsInOrder(t *testing.T) {
+	t.Parallel()
+	var gotParts []minio.CompletePart
+	core := &fakeCore{
+		completeMultipartUploadFn: func(_ context.Context, _, _, _ string, parts []minio.CompletePart, _ minio.PutObjectOptions) (minio.UploadInfo, error) {
+			gotParts = parts
+			return minio.UploadInfo{}, nil
+		},
+	}
+	a := newTestAdapter(core, nil)
+
+	input := []contracts.CompletedPart{
+		{PartNumber: 1, ETag: "etag-1"},
+		{PartNumber: 2, ETag: "etag-2"},
+		{PartNumber: 3, ETag: "etag-3"},
+	}
+	err := a.CompleteMultipartUpload(context.Background(), "file-abc", "upload-id-1", input)
+
+	require.NoError(t, err)
+	require.Len(t, gotParts, 3)
+	assert.Equal(t, 1, gotParts[0].PartNumber)
+	assert.Equal(t, "etag-1", gotParts[0].ETag)
+	assert.Equal(t, 2, gotParts[1].PartNumber)
+	assert.Equal(t, "etag-2", gotParts[1].ETag)
+	assert.Equal(t, 3, gotParts[2].PartNumber)
+	assert.Equal(t, "etag-3", gotParts[2].ETag)
+}
+
+func TestCompleteMultipartUpload_Error(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("complete failed")
+	core := &fakeCore{
+		completeMultipartUploadFn: func(_ context.Context, _, _, _ string, _ []minio.CompletePart, _ minio.PutObjectOptions) (minio.UploadInfo, error) {
+			return minio.UploadInfo{}, boom
+		},
+	}
+	a := newTestAdapter(core, nil)
+
+	err := a.CompleteMultipartUpload(context.Background(), "file-abc", "upload-id-1", []contracts.CompletedPart{{PartNumber: 1, ETag: "e"}})
+
+	assert.ErrorIs(t, err, boom)
+}
+
+func TestCompleteMultipartUpload_EmptyParts(t *testing.T) {
+	t.Parallel()
+	var gotParts []minio.CompletePart
+	core := &fakeCore{
+		completeMultipartUploadFn: func(_ context.Context, _, _, _ string, parts []minio.CompletePart, _ minio.PutObjectOptions) (minio.UploadInfo, error) {
+			gotParts = parts
+			return minio.UploadInfo{}, nil
+		},
+	}
+	a := newTestAdapter(core, nil)
+
+	err := a.CompleteMultipartUpload(context.Background(), "file-abc", "upload-id-1", nil)
+
+	require.NoError(t, err)
+	assert.Empty(t, gotParts)
+}
+
+// ---------- AbortMultipartUpload ----------
+
+func TestAbortMultipartUpload_Happy(t *testing.T) {
+	t.Parallel()
+	var called bool
+	core := &fakeCore{
+		abortMultipartUploadFn: func(_ context.Context, _, _, _ string) error {
+			called = true
+			return nil
+		},
+	}
+	a := newTestAdapter(core, nil)
+
+	err := a.AbortMultipartUpload(context.Background(), "file-abc", "upload-id-1")
+
+	require.NoError(t, err)
+	assert.True(t, called)
+}
+
+func TestAbortMultipartUpload_Error(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("abort failed")
+	core := &fakeCore{
+		abortMultipartUploadFn: func(_ context.Context, _, _, _ string) error { return boom },
+	}
+	a := newTestAdapter(core, nil)
+
+	err := a.AbortMultipartUpload(context.Background(), "file-abc", "upload-id-1")
+
+	assert.ErrorIs(t, err, boom)
+}
+
+// ---------- GetObject ----------
+
+func TestGetObject_Happy(t *testing.T) {
+	t.Parallel()
+	content := "hello from object storage"
+	rs := &fakeReaderStat{
+		reader: bytes.NewReader([]byte(content)),
+		statFn: func() (minio.ObjectInfo, error) {
+			return minio.ObjectInfo{Size: int64(len(content))}, nil
+		},
+	}
+	getter := &fakeGetter{
+		getObjectFn: func(_ context.Context, _, _ string, _ minio.GetObjectOptions) (readerStat, error) {
+			return rs, nil
+		},
+	}
+	a := newTestAdapter(nil, getter)
+
+	rc, size, err := a.GetObject(context.Background(), "file-abc")
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(len(content)), size)
+	assert.False(t, rs.closed, "reader must NOT be closed on success")
+
+	body, _ := io.ReadAll(rc)
+	assert.Equal(t, content, string(body))
+}
+
+func TestGetObject_GetterError(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("getter failed")
+	getter := &fakeGetter{
+		getObjectFn: func(_ context.Context, _, _ string, _ minio.GetObjectOptions) (readerStat, error) {
+			return nil, boom
+		},
+	}
+	a := newTestAdapter(nil, getter)
+
+	rc, size, err := a.GetObject(context.Background(), "file-abc")
+
+	assert.ErrorIs(t, err, boom)
+	assert.Nil(t, rc)
+	assert.Zero(t, size)
+}
+
+func TestGetObject_StatError_ClosesReader(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("stat failed")
+	rs := &fakeReaderStat{
+		reader: bytes.NewReader(nil),
+		statFn: func() (minio.ObjectInfo, error) { return minio.ObjectInfo{}, boom },
+	}
+	getter := &fakeGetter{
+		getObjectFn: func(_ context.Context, _, _ string, _ minio.GetObjectOptions) (readerStat, error) {
+			return rs, nil
+		},
+	}
+	a := newTestAdapter(nil, getter)
+
+	rc, size, err := a.GetObject(context.Background(), "file-abc")
+
+	assert.ErrorIs(t, err, boom)
+	assert.Nil(t, rc)
+	assert.Zero(t, size)
+	assert.True(t, rs.closed, "reader must be closed when Stat returns an error")
+}
+
+// ---------- NewS3Adapter constructor ----------
+
+func TestNewS3Adapter_InvalidEndpoint(t *testing.T) {
+	t.Parallel()
+	// An endpoint containing a scheme causes minio.New to return an error.
+	_, err := NewS3Adapter("http://invalid::endpoint", "key", "secret", "bucket", false)
+	assert.Error(t, err)
+}
+
+// ---------- compile-time interface guard ----------
+
+func TestAdapterSatisfiesPort(t *testing.T) {
+	t.Parallel()
+	// Verified by the var _ guard in object_storage.go; this test acts as
+	// human-readable documentation that the interface contract is met.
+	_ = strings.TrimSpace // keep import used
+	var _ interface {
+		GetObject(context.Context, string) (io.ReadCloser, int64, error)
+	} = (*S3Adapter)(nil)
+}

--- a/app/internal/integration/garagetest/garage.go
+++ b/app/internal/integration/garagetest/garage.go
@@ -1,0 +1,290 @@
+//go:build integration
+
+// Package garagetest provides a shared helper for integration tests that need
+// a real S3-compatible object store. It spins up a Garage (garagehq.deuxfleurs.fr)
+// container via testcontainers and provisions a bucket + key pair ready for use.
+// Compiled only under the `integration` build tag so the default `go test ./...`
+// run stays fast and Docker-free.
+package garagetest
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	tcexec "github.com/testcontainers/testcontainers-go/exec"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+const (
+	// defaultGarageImage is from docker.io, NOT mirror.gcr.io, because the
+	// dxflrs namespace is not mirrored to mirror.gcr.io. Override with
+	// PASSWORDEXCHANGE_TEST_GARAGE_IMAGE when a different registry or version is needed.
+	defaultGarageImage = "docker.io/dxflrs/garage:v1.0.1"
+	imageEnvVar        = "PASSWORDEXCHANGE_TEST_GARAGE_IMAGE"
+
+	s3Port = "3900/tcp"
+
+	garageToml = `
+metadata_dir = "/tmp/garage/meta"
+data_dir = "/tmp/garage/data"
+db_engine = "sqlite"
+replication_factor = 1
+
+[rpc_bind_addr]
+ip = "0.0.0.0"
+port = 3901
+
+[s3_api]
+s3_region = "us-east-1"
+api_bind_addr = "0.0.0.0:3900"
+root_domain = ".s3.garage.localhost"
+
+[s3_web]
+bind_addr = "0.0.0.0:3902"
+root_domain = ".web.garage.localhost"
+index = "index.html"
+error_document = "error/@@CODE@@.html"
+
+[admin]
+api_bind_addr = "0.0.0.0:3903"
+`
+)
+
+func garageImage() string {
+	if img := os.Getenv(imageEnvVar); img != "" {
+		return img
+	}
+	return defaultGarageImage
+}
+
+// StartGarage launches a throwaway Garage container, provisions a bucket named
+// "test-bucket" and an access key, and returns the S3 endpoint plus credentials.
+// All resources are torn down automatically via t.Cleanup. Intended for use when
+// each test needs its own isolated container; for shared-container TestMain use,
+// call MustStart instead.
+func StartGarage(t *testing.T) (endpoint, accessKey, secretKey, bucket string) {
+	t.Helper()
+
+	if _, ok := os.LookupEnv("TESTCONTAINERS_RYUK_DISABLED"); !ok {
+		t.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
+	}
+
+	tomlPath := t.TempDir() + "/garage.toml"
+	require.NoError(t, os.WriteFile(tomlPath, []byte(garageToml), 0o644))
+
+	endpoint, accessKey, secretKey, bucket, container, err := startContainer(context.Background(), tomlPath)
+	require.NoError(t, err, "start garage container")
+
+	t.Cleanup(func() {
+		if err := testcontainers.TerminateContainer(container); err != nil {
+			t.Logf("failed to terminate garage container: %v", err)
+		}
+	})
+	return endpoint, accessKey, secretKey, bucket
+}
+
+// MustStart launches a Garage container and provisions it, returning the S3
+// endpoint, credentials, bucket name, and a teardown func. It is intended for
+// use in TestMain where *testing.T is unavailable. On any setup error it calls
+// log.Fatal. The caller must call teardown() (not deferred — os.Exit in TestMain
+// does not run defers):
+//
+//	endpoint, key, secret, bucket, teardown := garagetest.MustStart()
+//	code := m.Run()
+//	teardown()
+//	os.Exit(code)
+func MustStart() (endpoint, accessKey, secretKey, bucket string, teardown func()) {
+	if _, ok := os.LookupEnv("TESTCONTAINERS_RYUK_DISABLED"); !ok {
+		if err := os.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true"); err != nil {
+			log.Fatalf("garagetest: set TESTCONTAINERS_RYUK_DISABLED: %v", err)
+		}
+	}
+
+	tmp, err := os.MkdirTemp("", "garagetest-*")
+	if err != nil {
+		log.Fatalf("garagetest: create temp dir: %v", err)
+	}
+	tomlPath := tmp + "/garage.toml"
+	if err := os.WriteFile(tomlPath, []byte(garageToml), 0o644); err != nil {
+		log.Fatalf("garagetest: write garage.toml: %v", err)
+	}
+
+	endpoint, accessKey, secretKey, bucket, container, err := startContainer(context.Background(), tomlPath)
+	if err != nil {
+		log.Fatalf("garagetest: %v", err)
+	}
+
+	teardown = func() {
+		_ = os.RemoveAll(tmp)
+		if err := testcontainers.TerminateContainer(container); err != nil {
+			log.Printf("garagetest: terminate container: %v", err)
+		}
+	}
+	return endpoint, accessKey, secretKey, bucket, teardown
+}
+
+// startContainer starts and fully provisions a Garage container, returning the
+// endpoint, credentials, bucket, the container handle (for teardown), and any error.
+func startContainer(ctx context.Context, tomlPath string) (endpoint, accessKey, secretKey, bucket string, container testcontainers.Container, err error) {
+	req := testcontainers.ContainerRequest{
+		Image:        garageImage(),
+		ExposedPorts: []string{s3Port},
+		Cmd:          []string{"server"},
+		Files: []testcontainers.ContainerFile{
+			{
+				HostFilePath:      tomlPath,
+				ContainerFilePath: "/etc/garage.toml",
+				FileMode:          0o644,
+			},
+		},
+		WaitingFor: wait.ForListeningPort(s3Port).WithStartupTimeout(60 * time.Second),
+	}
+
+	container, err = testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		return "", "", "", "", nil, fmt.Errorf("start garage container: %w", err)
+	}
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		return "", "", "", "", container, fmt.Errorf("get container host: %w", err)
+	}
+	mappedPort, err := container.MappedPort(ctx, s3Port)
+	if err != nil {
+		return "", "", "", "", container, fmt.Errorf("get mapped port: %w", err)
+	}
+	endpoint = net.JoinHostPort(host, mappedPort.Port())
+
+	// Give the node a moment to register itself after the TCP port is open.
+	time.Sleep(2 * time.Second)
+
+	nodeID, err := getNodeID(ctx, container)
+	if err != nil {
+		return "", "", "", "", container, err
+	}
+
+	if err := assignLayout(ctx, container, nodeID); err != nil {
+		return "", "", "", "", container, err
+	}
+
+	if _, err := execAndCapture(ctx, container, []string{"garage", "layout", "apply", "--version", "1"}); err != nil {
+		return "", "", "", "", container, err
+	}
+	if _, err := execAndCapture(ctx, container, []string{"garage", "bucket", "create", "test-bucket"}); err != nil {
+		return "", "", "", "", container, err
+	}
+
+	keyOut, err := execAndCapture(ctx, container, []string{"garage", "key", "create", "test-key"})
+	if err != nil {
+		return "", "", "", "", container, err
+	}
+	accessKey, secretKey, err = parseKeyCredentials(keyOut)
+	if err != nil {
+		return "", "", "", "", container, err
+	}
+
+	if _, err := execAndCapture(ctx, container, []string{
+		"garage", "bucket", "allow",
+		"--read", "--write", "--owner",
+		"test-bucket",
+		"--key", "test-key",
+	}); err != nil {
+		return "", "", "", "", container, err
+	}
+
+	return endpoint, accessKey, secretKey, "test-bucket", container, nil
+}
+
+// getNodeID retrieves the Garage node ID via `garage node id -q`.
+func getNodeID(ctx context.Context, container testcontainers.Container) (string, error) {
+	out, err := execAndCapture(ctx, container, []string{"garage", "node", "id", "-q"})
+	if err != nil {
+		return "", fmt.Errorf("get node id: %w", err)
+	}
+	id := strings.TrimSpace(out)
+	if id == "" {
+		return "", fmt.Errorf("garage node id returned empty output")
+	}
+	// Output may be "<hexid>@<host>:<port>" — take only the hex ID part.
+	if idx := strings.Index(id, "@"); idx >= 0 {
+		id = id[:idx]
+	}
+	return id, nil
+}
+
+// assignLayout assigns the node to a layout zone with a retry loop to handle
+// the brief window where the node has not yet registered with itself.
+func assignLayout(ctx context.Context, container testcontainers.Container, nodeID string) error {
+	const maxAttempts = 10
+	for i := range maxAttempts {
+		exitCode, _, err := container.Exec(ctx, []string{
+			"garage", "layout", "assign",
+			"-z", "dc1",
+			"-c", "1G",
+			nodeID,
+		}, tcexec.Multiplexed())
+		if err == nil && exitCode == 0 {
+			return nil
+		}
+		if i < maxAttempts-1 {
+			time.Sleep(500 * time.Millisecond)
+		}
+	}
+	return fmt.Errorf("garage layout assign did not succeed after %d attempts", maxAttempts)
+}
+
+// execAndCapture runs a command in the container and returns stdout on exit 0,
+// or an error if the command fails or exits non-zero.
+func execAndCapture(ctx context.Context, container testcontainers.Container, cmd []string) (string, error) {
+	exitCode, reader, err := container.Exec(ctx, cmd, tcexec.Multiplexed())
+	if err != nil {
+		return "", fmt.Errorf("exec %v: %w", cmd, err)
+	}
+
+	var out string
+	if reader != nil {
+		data, readErr := io.ReadAll(reader)
+		if readErr != nil {
+			return "", fmt.Errorf("read output of %v: %w", cmd, readErr)
+		}
+		out = strings.TrimSpace(string(data))
+	}
+
+	if exitCode != 0 {
+		return "", fmt.Errorf("command %v exited %d\noutput: %s", cmd, exitCode, out)
+	}
+	return out, nil
+}
+
+// parseKeyCredentials extracts Key ID and Secret key from `garage key create` output.
+// Output lines look like:
+//
+//	Key ID:     GKxxxx
+//	Secret key: xxxxxx
+func parseKeyCredentials(output string) (keyID, secretKey string, err error) {
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if after, ok := strings.CutPrefix(line, "Key ID:"); ok {
+			keyID = strings.TrimSpace(after)
+		}
+		if after, ok := strings.CutPrefix(line, "Secret key:"); ok {
+			secretKey = strings.TrimSpace(after)
+		}
+	}
+	if keyID == "" || secretKey == "" {
+		return "", "", fmt.Errorf("could not parse credentials from output:\n%s", output)
+	}
+	return keyID, secretKey, nil
+}


### PR DESCRIPTION
## Summary

- **Seam refactor** (`object_storage.go`): introduce unexported interfaces `multipartCore`, `objectGetter`, and `readerStat` so `*minio.Core` / `*minio.Client` can be swapped with fakes in tests. `NewS3Adapter` signature and all method behaviours are unchanged; `forms.go` untouched.
- **14 unit tests** (`object_storage_test.go`): function-field fakes + `testify/require`/`assert`, covering every public method — happy paths, error propagation, `contracts.CompletedPart` → `minio.CompletePart` ordering, and the close-on-Stat-error invariant for `GetObject`.
- **Garage integration helper** (`internal/integration/garagetest/garage.go`, `integration` build tag): spins up `dxflrs/garage:v1.0.1` via testcontainers generic container, provisions bucket + key, tears down via `t.Cleanup`. Image defaults to `docker.io/dxflrs/garage:v1.0.1` (not on `mirror.gcr.io` — noted in comment) with `PASSWORDEXCHANGE_TEST_GARAGE_IMAGE` override.
- **4 blackbox integration tests** (`object_storage_integration_test.go`): multipart round-trip (5 MiB min-part + 1 KiB final, SHA-256 verified), abort discards upload, missing-key error, and bad-ETag rejection on complete.

> **Note on scope:** the issue mentioned `DeleteObject`, but neither `ObjectStoragePort` nor `S3Adapter` defines that method — the issue text is stale. Tests cover the 5 real methods only.

## Test plan

- [ ] `cd app && go test ./internal/domains/message/adapters/secondary/s3/... -v` — 14 unit tests pass
- [ ] `cd app && go test -tags=integration ./internal/domains/message/adapters/secondary/s3/... -v` — 4 Garage integration tests pass (requires Docker)
- [ ] `cd app && go test ./...` — full unit suite still green
- [ ] `./test-build.sh` — build verification passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)