### PR TITLE
feat(buildinfo): inject application version via ldflags (#533)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,8 @@ jobs:
           context: .
           push: true
           tags: ghcr.io/anthony-bible/passwordexchange-container-${{ env.PHASE }}:${{ env.VERSION }}
+          build-args: |
+            VERSION=${{ env.VERSION }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,10 @@ RUN go mod download
 # Copy the source code
 COPY app/ ./
 
+ARG VERSION=dev
+
 # Build the application
-RUN CGO_ENABLED=1 GOOS=linux go build -o app
+RUN CGO_ENABLED=1 GOOS=linux go build -ldflags "-X github.com/Anthony-Bible/password-exchange/app/internal/shared/buildinfo.Version=${VERSION}" -o app
 
 # Final stage
 FROM ubuntu:24.04

--- a/app/cmd/version/version.go
+++ b/app/cmd/version/version.go
@@ -1,0 +1,22 @@
+package version
+
+import (
+	"fmt"
+
+	"github.com/Anthony-Bible/password-exchange/app/cmd"
+	"github.com/Anthony-Bible/password-exchange/app/internal/shared/buildinfo"
+	"github.com/spf13/cobra"
+)
+
+// Cmd is exported so tests can drive it directly.
+var Cmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the application version",
+	Run: func(c *cobra.Command, args []string) {
+		fmt.Fprintln(c.OutOrStdout(), buildinfo.Version)
+	},
+}
+
+func init() {
+	cmd.RootCmd.AddCommand(Cmd)
+}

--- a/app/cmd/version/version_test.go
+++ b/app/cmd/version/version_test.go
@@ -1,0 +1,24 @@
+package version_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/Anthony-Bible/password-exchange/app/cmd/version"
+	"github.com/Anthony-Bible/password-exchange/app/internal/shared/buildinfo"
+)
+
+func TestVersionCommand_PrintsBuildVersion(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	version.Cmd.SetOut(&buf)
+	version.Cmd.SetErr(&buf)
+
+	version.Cmd.Run(version.Cmd, nil)
+
+	got := strings.TrimSpace(buf.String())
+	if got != buildinfo.Version {
+		t.Errorf("version command output = %q, want %q", got, buildinfo.Version)
+	}
+}

--- a/app/internal/domains/message/adapters/primary/api/handlers.go
+++ b/app/internal/domains/message/adapters/primary/api/handlers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Anthony-Bible/password-exchange/app/internal/domains/message/domain"
 	"github.com/Anthony-Bible/password-exchange/app/internal/domains/message/ports/primary"
 	"github.com/Anthony-Bible/password-exchange/app/internal/domains/message/ports/secondary"
+	"github.com/Anthony-Bible/password-exchange/app/internal/shared/buildinfo"
 	"github.com/Anthony-Bible/password-exchange/app/internal/shared/logging"
 	"github.com/gin-gonic/gin"
 )
@@ -473,7 +474,7 @@ func (h *MessageAPIHandler) HealthCheck(c *gin.Context) {
 
 	response := models.HealthCheckResponse{
 		Status:    overall,
-		Version:   "1.0.0", // TODO: Get from build info
+		Version:   buildinfo.Version,
 		Timestamp: time.Now(),
 		Services:  services,
 	}
@@ -550,7 +551,7 @@ func (h *MessageAPIHandler) APIInfo(c *gin.Context) {
 		Msg("API info requested")
 
 	response := models.APIInfoResponse{
-		Version:       "1.0.0",
+		Version:       buildinfo.Version,
 		Documentation: "/api/v1/docs", // TODO: Implement swagger docs
 		Endpoints: map[string]string{
 			"submit":  "POST /api/v1/messages",

--- a/app/internal/domains/message/adapters/primary/api/handlers_test.go
+++ b/app/internal/domains/message/adapters/primary/api/handlers_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Anthony-Bible/password-exchange/app/internal/domains/message/adapters/primary/api/models"
 	"github.com/Anthony-Bible/password-exchange/app/internal/domains/message/domain"
 	"github.com/Anthony-Bible/password-exchange/app/internal/domains/message/ports/contracts"
+	"github.com/Anthony-Bible/password-exchange/app/internal/shared/buildinfo"
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
@@ -348,7 +349,7 @@ func TestHealthCheck(t *testing.T) {
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	assert.NoError(t, err)
 	assert.Equal(t, "healthy", response.Status)
-	assert.Equal(t, "1.0.0", response.Version)
+	assert.Equal(t, buildinfo.Version, response.Version)
 	assert.Equal(t, "healthy", response.Services["database"])
 	assert.Equal(t, "healthy", response.Services["encryption"])
 	assert.NotContains(t, response.Services, "email")
@@ -462,7 +463,7 @@ func TestAPIInfo(t *testing.T) {
 	var response models.APIInfoResponse
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	assert.NoError(t, err)
-	assert.Equal(t, "1.0.0", response.Version)
+	assert.Equal(t, buildinfo.Version, response.Version)
 	assert.Contains(t, response.Endpoints, "submit")
 	assert.Contains(t, response.Endpoints, "access")
 	assert.Contains(t, response.Endpoints, "decrypt")

--- a/app/internal/shared/buildinfo/buildinfo.go
+++ b/app/internal/shared/buildinfo/buildinfo.go
@@ -1,0 +1,9 @@
+// Package buildinfo exposes build-time metadata injected via -ldflags.
+package buildinfo
+
+// Version is the application version, set at build time via:
+//
+//	-ldflags "-X github.com/Anthony-Bible/password-exchange/app/internal/shared/buildinfo.Version=<version>"
+//
+// It defaults to "dev" for local builds without ldflags.
+var Version = "dev"

--- a/app/internal/shared/buildinfo/buildinfo_test.go
+++ b/app/internal/shared/buildinfo/buildinfo_test.go
@@ -1,0 +1,14 @@
+package buildinfo_test
+
+import (
+	"testing"
+
+	"github.com/Anthony-Bible/password-exchange/app/internal/shared/buildinfo"
+)
+
+func TestVersionDefaultIsDev(t *testing.T) {
+	t.Parallel()
+	if buildinfo.Version != "dev" {
+		t.Errorf("default Version = %q, want %q", buildinfo.Version, "dev")
+	}
+}

--- a/app/main.go
+++ b/app/main.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/Anthony-Bible/password-exchange/app/cmd/email"
 	_ "github.com/Anthony-Bible/password-exchange/app/cmd/encryption"
 	_ "github.com/Anthony-Bible/password-exchange/app/cmd/reminder"
+	_ "github.com/Anthony-Bible/password-exchange/app/cmd/version"
 	_ "github.com/Anthony-Bible/password-exchange/app/cmd/web"
 )
 

--- a/test-build.sh
+++ b/test-build.sh
@@ -38,7 +38,8 @@ echo "Protobuf generation successful!"
 echo "Testing Go build..."
 cd app
 go mod tidy
-go build -o app
+VERSION=$(git describe --tags --always 2>/dev/null || echo dev)
+go build -ldflags "-X github.com/Anthony-Bible/password-exchange/app/internal/shared/buildinfo.Version=${VERSION}" -o app
 if [ $? -eq 0 ]; then
   echo "Go build successful!"
 else


### PR DESCRIPTION
## Summary

- Adds `app/internal/shared/buildinfo` package with `var Version = "dev"` injectable via `-ldflags`
- Replaces hardcoded `"1.0.0"` in `/api/v1/health` and `/api/v1/info` handlers with `buildinfo.Version`
- `test-build.sh` now captures `git describe --tags --always` and passes it through `-ldflags`
- `Dockerfile` accepts `ARG VERSION=dev` and forwards it to `go build` via `-ldflags`
- CI `build-and-push-main` step passes `VERSION=${{ env.VERSION }}` as a Docker build arg

## Test plan

- [ ] `go test ./internal/domains/message/adapters/primary/api/... ./internal/shared/buildinfo/... -v` — all pass
- [ ] `strings` check confirms `v9.9.9-test` baked into binary when built with matching ldflag
- [ ] `test-build.sh` passes end-to-end
- [ ] Health and info endpoints return `"dev"` locally; CI-built images report their git tag/SHA

Closes #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)